### PR TITLE
This fixes manufacturer id being sent out as a decimal instead of a hex

### DIFF
--- a/components/bluetooth_proxy/src/lib.rs
+++ b/components/bluetooth_proxy/src/lib.rs
@@ -132,7 +132,7 @@ impl Module for UbiHomePlatform {
                                 service_uuids: services.iter().map(|s| s.to_string()).collect(),
                                 manufacturer_data: manufacturer_data
                                     .iter()
-                                    .map(|(k, v)| (k.to_string(), v.clone()))
+                                    .map(|(k, v)| (format!("{:x}", k), v.clone()))
                                     .collect(),
                             },
                         ))


### PR DESCRIPTION
btleplug will automatically convert BLE advertisement data using LE and using u16 decimal value. When manufacturer_data is about to be sent out, the decimal value is turned into a string representation. Home Assistant expects the manufacturer_data id to be LE hexadecimal values.

The fix to this is to replace the to_string and instead write a string where the key is converted with u16 decimal into its hexadecimal form as a string. Home Assistant is able to properly parse manufacturer_data id and not crash since it does not expect there to be a value > 2^16. 