### PR TITLE
docs: fetch getting-started version dynamically

### DIFF
--- a/documentation/package-lock.json
+++ b/documentation/package-lock.json
@@ -11,7 +11,7 @@
 				"@yeskunall/astro-umami": "^0.0.8",
 				"astro": "^6.3.3",
 				"sharp": "^0.34.5",
-				"starlight-latest-version": "^0.7.0",
+				"starlight-latest-version": "file:vendor/starlight-latest-version",
 				"starlight-links-validator": "^0.24.0",
 				"starlight-showcases": "^0.3.2",
 				"starlight-sidebar-topics": "^0.7.1",
@@ -6767,17 +6767,8 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/starlight-latest-version": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/starlight-latest-version/-/starlight-latest-version-0.7.0.tgz",
-			"integrity": "sha512-KEvwQP7t9SsCyBsVnf9wO3TVPXKFGAAya5KoOGHN0x2wVCyOkUt5qw8lKPYwgRo6dOHAYfurqz4Ah0KqSqRV+g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=22.12.0"
-			},
-			"peerDependencies": {
-				"@astrojs/starlight": ">=0.38",
-				"astro": "^6.0.4"
-			}
+			"resolved": "vendor/starlight-latest-version",
+			"link": true
 		},
 		"node_modules/starlight-links-validator": {
 			"version": "0.24.0",
@@ -7589,6 +7580,17 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"vendor/starlight-latest-version": {
+			"version": "0.7.0-issue85-getLatestVersion",
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.23.0"
+			},
+			"peerDependencies": {
+				"@astrojs/starlight": ">=0.38",
+				"astro": "^6.0.4"
 			}
 		}
 	}

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -16,7 +16,7 @@
 		"astro": "^6.3.3",
 		"sharp": "^0.34.5",
 		"starlight-showcases": "^0.3.2",
-		"starlight-latest-version": "^0.7.0",
+		"starlight-latest-version": "file:vendor/starlight-latest-version",
 		"starlight-links-validator": "^0.24.0",
 		"starlight-sidebar-topics": "^0.7.1",
 		"starlight-site-graph": "^0.5.0",

--- a/documentation/src/content/docs/getting_started/index.mdx
+++ b/documentation/src/content/docs/getting_started/index.mdx
@@ -7,9 +7,33 @@ next:
 ---
 
 import { Code, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { getLatestVersion } from 'virtual:starlight-latest-version';
 import linuxConfig from './linux.yml?raw';
 import windowsConfig from './windows.yml?raw';
 import macosConfig from './macos.yml?raw';
+
+export const latest = await getLatestVersion();
+export const releaseVersion = latest.versionAvailable ? latest.version : 'v0.14.0';
+export const displayVersion = latest.versionAvailable ? latest.versionWithoutPrefix : '0.14.0';
+export const downloadUrl = (file) => `https://github.com/UbiHome/UbiHome/releases/download/${releaseVersion}/${file}`;
+export const nixRun = `./ubihome run
+UbiHome - ${displayVersion}
+LogDirectory: /home/codespace/.local/share
+Config file path: /workspaces/ubihome/config.yaml
+Binary Sensor 'bluetooth_connected' output: false
+Sensor 'ram_usage' output: 38.3144
+Button 'my_button' pressed.
+Command executed successfully with no output.
+# End the process with ctrl+c`;
+export const windowsRun = `./ubihome.exe run
+UbiHome - ${displayVersion}
+LogDirectory: /home/codespace/.local/share
+Config file path: /workspaces/UbiHome/config.yaml
+Binary Sensor 'bluetooth_connected' output: false
+Sensor 'ram_usage' output: 38.3144
+Button 'my_button' pressed.
+Command executed successfully with no output.
+# End the process with ctrl+c`;
 export const labels = [
   { range: '6', label: '              Generate here: https://ubihome.github.io/features/connectivity/native_api.html' },
 ];
@@ -22,17 +46,13 @@ export const labels = [
 
     1. Download and extract the archive and place the ubihome executable in a directory of your choice.
 
-        | Devices            | Download                                                                                                             | Target                        |
-        | ------------------ | -------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-        | Any Linux          | [TAR Link](https://github.com/UbiHome/UbiHome/releases/download/v0.14.0/ubihome-Linux-musl-x86_64.tar.gz)         | x86_64-unknown-linux-musl     |
-        | Raspberry Pi 3     | [TAR Link](https://github.com/UbiHome/UbiHome/releases/download/v0.14.0/ubihome-Linux-musleabi-armv7.tar.gz)      | armv7-unknown-linux-musleabi  |
-        | Raspberry Pi Zero 2| [TAR Link](https://github.com/UbiHome/UbiHome/releases/download/v0.14.0/ubihome-Linux-musleabi-arm.tar.gz)        | arm-unknown-linux-musleabi    |
+        | Devices            | Download                                                                          | Target                        |
+        | ------------------ | --------------------------------------------------------------------------------- | ----------------------------- |
+        | Any Linux          | <a href={downloadUrl('ubihome-Linux-musl-x86_64.tar.gz')}>TAR Link</a>            | x86_64-unknown-linux-musl     |
+        | Raspberry Pi 3     | <a href={downloadUrl('ubihome-Linux-musleabi-armv7.tar.gz')}>TAR Link</a>         | armv7-unknown-linux-musleabi  |
+        | Raspberry Pi Zero 2| <a href={downloadUrl('ubihome-Linux-musleabi-arm.tar.gz')}>TAR Link</a>           | arm-unknown-linux-musleabi    |
 
-       ```bash
-       # You might have to use a different link from the table above depending on your device type
-       curl -L -o ubihome.tar.gz https://github.com/UbiHome/UbiHome/releases/download/v0.14.0/ubihome-Linux-musleabi-armv7.tar.gz
-       tar xvzf ./ubihome.tar.gz
-       ```
+       <Code code={`# You might have to use a different link from the table above depending on your device type\ncurl -L -o ubihome.tar.gz ${downloadUrl('ubihome-Linux-musleabi-armv7.tar.gz')}\ntar xvzf ./ubihome.tar.gz`} lang="bash" />
 
     2. Edit the configuration file `config.yaml` in the same directory as the executable. Example:
 
@@ -40,17 +60,7 @@ export const labels = [
 
     3. Try it out:
 
-       ```bash
-       ./ubihome run
-       UbiHome - 0.14.0
-       LogDirectory: /home/codespace/.local/share
-       Config file path: /workspaces/ubihome/config.yaml
-       Binary Sensor 'bluetooth_connected' output: false
-       Sensor 'ram_usage' output: 38.3144
-       Button 'my_button' pressed.
-       Command executed successfully with no output.
-       # End the process with ctrl+c
-       ```
+       <Code code={nixRun} lang="bash" />
 
     4. You should be able to see your device in Home Assistant now.
 
@@ -80,14 +90,11 @@ export const labels = [
 
     1. Download and extract the archive and place the ubihome executable in a directory of your choice.
 
-        | Device      | Download                                                                                                         | Target                    |
-        | ----------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------- |
-        | Windows 11  | [ZIP Link](https://github.com/UbiHome/UbiHome/releases/download/v0.14.0/ubihome-Windows-msvc-x86_64.zip)         | x86_64-pc-windows-msvc    |
+        | Device      | Download                                                             | Target                    |
+        | ----------- | -------------------------------------------------------------------- | ------------------------- |
+        | Windows 11  | <a href={downloadUrl('ubihome-Windows-msvc-x86_64.zip')}>ZIP Link</a> | x86_64-pc-windows-msvc    |
 
-       ```powershell
-       Invoke-WebRequest -OutFile ubihome.zip -Uri https://github.com/UbiHome/UbiHome/releases/download/v0.14.0/ubihome-Windows-msvc-x86_64.zip
-       Expand-Archive -Force ubihome.zip ./
-       ```
+       <Code code={`Invoke-WebRequest -OutFile ubihome.zip -Uri ${downloadUrl('ubihome-Windows-msvc-x86_64.zip')}\nExpand-Archive -Force ubihome.zip ./`} lang="powershell" />
 
     2. Edit the configuration file `config.yaml` in the same directory as the executable. Example:
 
@@ -95,17 +102,7 @@ export const labels = [
 
     3. Try it out:
 
-       ```bash
-       ./ubihome.exe run
-       UbiHome - 0.14.0
-       LogDirectory: /home/codespace/.local/share
-       Config file path: /workspaces/UbiHome/config.yaml
-       Binary Sensor 'bluetooth_connected' output: false
-       Sensor 'ram_usage' output: 38.3144
-       Button 'my_button' pressed.
-       Command executed successfully with no output.
-       # End the process with ctrl+c
-       ```
+       <Code code={windowsRun} lang="bash" />
 
     4. You should be able to see your device in Home Assistant now.
 
@@ -135,16 +132,12 @@ export const labels = [
     <Steps>
 
     1. Download and extract the archive and place the ubihome executable in a directory of your choice.
-        | Device                              | Download                                                                                                      | Target                |
-        | ----------------------------------- | ------------------------------------------------------------------------------------------------------------- | --------------------- |
-        | MacOS (Intel)                       | [TAR Link](https://github.com/UbiHome/UbiHome/releases/download/v0.14.0/ubihome-macos-x86_64.tar.gz)       | x86_64-apple-darwin   |
-        | MacOS (Apple Silicon / M series)    | [TAR Link](https://github.com/UbiHome/UbiHome/releases/download/v0.14.0/ubihome-macos-aarch64.tar.gz)      | aarch64-apple-darwin  |
+        | Device                              | Download                                                        | Target                |
+        | ----------------------------------- | --------------------------------------------------------------- | --------------------- |
+        | MacOS (Intel)                       | <a href={downloadUrl('ubihome-macos-x86_64.tar.gz')}>TAR Link</a>  | x86_64-apple-darwin   |
+        | MacOS (Apple Silicon / M series)    | <a href={downloadUrl('ubihome-macos-aarch64.tar.gz')}>TAR Link</a> | aarch64-apple-darwin  |
 
-       ```bash
-       # You might have to use a different link from the table above depending on your device type
-       curl -L -o ubihome.tar.gz https://github.com/UbiHome/UbiHome/releases/download/v0.14.0/ubihome-macos-aarch64.tar.gz
-       tar xvzf ./ubihome.tar.gz
-       ```
+       <Code code={`# You might have to use a different link from the table above depending on your device type\ncurl -L -o ubihome.tar.gz ${downloadUrl('ubihome-macos-aarch64.tar.gz')}\ntar xvzf ./ubihome.tar.gz`} lang="bash" />
 
     2. Edit the configuration file `config.yaml` in the same directory as the executable.
 
@@ -154,17 +147,7 @@ export const labels = [
 
     3. Try it out:
 
-       ```bash
-       ./ubihome run
-       UbiHome - 0.14.0
-       LogDirectory: /home/codespace/.local/share
-       Config file path: /workspaces/ubihome/config.yaml
-       Binary Sensor 'bluetooth_connected' output: false
-       Sensor 'ram_usage' output: 38.3144
-       Button 'my_button' pressed.
-       Command executed successfully with no output.
-       # End the process with ctrl+c
-       ```
+       <Code code={nixRun} lang="bash" />
 
     4. You should be able to see your device in Home Assistant now.
 

--- a/documentation/vendor/starlight-latest-version/CHANGELOG.md
+++ b/documentation/vendor/starlight-latest-version/CHANGELOG.md
@@ -1,0 +1,122 @@
+# starlight-latest-version
+
+## 0.7.0
+
+### Minor Changes
+
+- [#68](https://github.com/trueberryless-org/starlight-latest-version/pull/68) [`d88a13f`](https://github.com/trueberryless-org/starlight-latest-version/commit/d88a13ff2225b8889421d87485f0b41598b729bb) Thanks [@trueberryless](https://github.com/trueberryless)! - Adds support for Astro v6, drops support for Astro v5.
+
+  ⚠️ **BREAKING CHANGE:** The minimum supported version of Starlight is now `0.38.0`.
+
+  Please follow the [upgrade guide](https://github.com/withastro/starlight/releases/tag/%40astrojs%2Fstarlight%400.38.0) to update your project.
+
+## 0.6.1
+
+### Patch Changes
+
+- [#64](https://github.com/trueberryless-org/starlight-latest-version/pull/64) [`187cf39`](https://github.com/trueberryless-org/starlight-latest-version/commit/187cf39b5700cb6618a942b23edad659a608afb1) Thanks [@trueberryless](https://github.com/trueberryless)! - Clean up package metadata.
+
+## 0.6.0
+
+### Minor Changes
+
+- [#58](https://github.com/trueberryless-org/starlight-latest-version/pull/58) [`f4776fb`](https://github.com/trueberryless-org/starlight-latest-version/commit/f4776fb8602ca30bbf9de592fa062b4e261a5225) Thanks [@trueberryless](https://github.com/trueberryless)! - Rename package from `starlight-plugin-show-latest-version` to `starlight-latest-version`.
+
+## 0.5.1
+
+### Patch Changes
+
+- [#52](https://github.com/trueberryless-org/starlight-latest-version/pull/52) [`1152b13`](https://github.com/trueberryless-org/starlight-latest-version/commit/1152b137cc1fec970fb604213bb7a71b7fff2597) Thanks [@trueberryless-org](https://github.com/apps/trueberryless-org)! - Setups trusted publishing using OpenID Connect (OIDC) authentication — no code changes.
+
+## 0.5.0
+
+### Minor Changes
+
+- [#32](https://github.com/trueberryless-org/starlight-latest-version/pull/32) [`9bdad60`](https://github.com/trueberryless-org/starlight-latest-version/commit/9bdad60c0f257bb5889c5ca9c0700d2e5c9dcc9b) Thanks [@trueberryless](https://github.com/trueberryless)! - ⚠️ **BREAKING CHANGE:** If you set [`showInSiteTitle`](https://starlight-latest-version.trueberryless.org/configuration#showinsitetitle) to `"deferred"`, you will have to [enable experimental sessions](https://docs.astro.build/en/reference/experimental-flags/sessions/#enabling-experimental-sessions) because the version will be cached for an hour.
+
+## 0.4.0
+
+### Minor Changes
+
+- [#29](https://github.com/trueberryless-org/starlight-latest-version/pull/29) [`3656c8f`](https://github.com/trueberryless-org/starlight-latest-version/commit/3656c8f9b35ca3cf4cade1791098301020bc117c) Thanks [@trueberryless](https://github.com/trueberryless)! - ⚠️ **BREAKING CHANGE:** The minimum supported version of Starlight is now version `0.32.0`.
+
+  Please use the `@astrojs/upgrade` command to upgrade your project:
+
+  ```sh
+  npx @astrojs/upgrade
+  ```
+
+## 0.3.1
+
+### Patch Changes
+
+- [#26](https://github.com/trueberryless-org/starlight-latest-version/pull/26) [`38e0418`](https://github.com/trueberryless-org/starlight-latest-version/commit/38e04186f90a4e575dde53339e290098574a2db4) Thanks [@trueberryless](https://github.com/trueberryless)! - Prevents the header title from being translated by automatic translation systems.
+
+## 0.3.0
+
+Special thanks to [@HiDeoo](https://github.com/HiDeoo) for their valuable feedback, which helped shape many of the improvements in this release.
+
+### Minor Changes
+
+- [#16](https://github.com/trueberryless-org/starlight-latest-version/pull/16) [`3de9964`](https://github.com/trueberryless-org/starlight-latest-version/commit/3de9964f4860928c42754c94e8be1c246b1cc674) Thanks [@trueberryless](https://github.com/trueberryless)! - Use [`server:defer`](https://docs.astro.build/en/reference/directives-reference/#serverdefer) in the `SiteTitle.astro` override component if [`showInSiteTitle`](https://starlight-latest-version.trueberryless.org/configuration/#showinsitetitle) is set to `"deferred"`.
+
+  ⚠️ **BREAKING CHANGE:** You now have to use some [server adapter](https://docs.astro.build/en/guides/on-demand-rendering/#server-adapters) if you set [`showInSiteTitle`](https://starlight-latest-version.trueberryless.org/configuration/#showinsitetitle) to `"deferred"`.
+
+  If you set the [`showInSiteTitle` configuration option](https://starlight-latest-version.trueberryless.org/configuration/#showinsitetitle) to `"deferred"`, you have to add a [server adapter](https://docs.astro.build/en/guides/on-demand-rendering/#server-adapters) because the plugin override now uses [`server:defer`](https://docs.astro.build/en/reference/directives-reference/#serverdefer) in order to fetch the latest version on-demand.
+
+  Read more about Server Islands in [this blog post](https://astro.build/blog/future-of-astro-server-islands/) or the [Astro documentation](https://docs.astro.build/en/guides/server-islands/).
+
+- [#14](https://github.com/trueberryless-org/starlight-latest-version/pull/14) [`8b0c933`](https://github.com/trueberryless-org/starlight-latest-version/commit/8b0c933c19b1fc1ed035e85a45168c0ec1b4f3a7) Thanks [@trueberryless](https://github.com/trueberryless)! - Add version support for NPM and GitLab.
+
+  ⚠️ **BREAKING CHANGE:** The configuration interface changed.
+
+  Please follow the steps below to use the plugin like before or read the [documentation](https://starlight-latest-version.trueberryless.org/configuration/#source) for the newly defined API.
+
+  Change the removed `repo` configuration to the new [`source`](https://starlight-latest-version.trueberryless.org/configuration/#source) configuration object:
+
+  ```diff
+   // astro.config.ts
+   starlightLatestVersion({
+  -  repo: "${slug}",
+  +  source: {
+  +    type: "github",
+  +    slug: "${slug}",
+  +  },
+   }),
+  ```
+
+  Note that you can now use `"npm"`, `"github"` or `"gitlab"` as the source type. This means that the plugin can be better customised to where you publish and release your packages.
+
+### Patch Changes
+
+- [#16](https://github.com/trueberryless-org/starlight-latest-version/pull/16) [`3de9964`](https://github.com/trueberryless-org/starlight-latest-version/commit/3de9964f4860928c42754c94e8be1c246b1cc674) Thanks [@trueberryless](https://github.com/trueberryless)! - Make override of Starlight `SiteTitle.astro` optional. You now have to opt-in by setting the new [`showInSiteTitle`](https://starlight-latest-version.trueberryless.org/configuration/#showinsitetitle) configuration option to `"true"` because it does not get overridden by default.
+
+- [#16](https://github.com/trueberryless-org/starlight-latest-version/pull/16) [`ae72935`](https://github.com/trueberryless-org/starlight-latest-version/commit/ae72935cbdca23c5e7d880d4f0c82c57c328e874) Thanks [@trueberryless](https://github.com/trueberryless)! - Add simple [fallback content](https://docs.astro.build/en/guides/server-islands/#server-island-fallback-content) for SiteTitle override Version Badge
+
+## 0.2.0
+
+### Minor Changes
+
+- [#12](https://github.com/trueberryless-org/starlight-latest-version/pull/12) [`c4c5257`](https://github.com/trueberryless-org/starlight-latest-version/commit/c4c525794ba68fe9f33d16194c6802632f5cba77) Thanks [@trueberryless](https://github.com/trueberryless)! - Adds support for Astro v5, drops support for Astro v4.
+
+  ⚠️ **BREAKING CHANGE:** The minimum supported version of Starlight is now `0.30.0`.
+
+  Please follow the [upgrade guide](https://github.com/withastro/starlight/releases/tag/%40astrojs/starlight%400.30.0) to update your project.
+
+  Note that the [`legacy.collections` flag](https://docs.astro.build/en/reference/legacy-flags/#collections) is not supported by this plugin and you should update your collections to use Astro's new Content Layer API.
+
+### Patch Changes
+
+- [`e29e231`](https://github.com/trueberryless-org/starlight-latest-version/commit/e29e2318eb36400ee5752017487518f07d091e31) Thanks [@trueberryless](https://github.com/trueberryless)! - Change Client JS to insert Raw HTML into div so it doesn't need rendering
+
+## 0.1.1
+
+### Patch Changes
+
+- [`d84a498`](https://github.com/trueberryless-org/starlight-latest-version/commit/d84a4981b81d3c4402834028e0f96f23be4c5a4e) Thanks [@trueberryless](https://github.com/trueberryless)! - Remove virtual export functionality because it's much harder than I though, maybe not even possible.
+
+## 0.1.0
+
+### Minor Changes
+
+- [`ab7b842`](https://github.com/trueberryless-org/starlight-latest-version/commit/ab7b842691b74692c513ecd5e4557112a7eccca6) Thanks [@trueberryless](https://github.com/trueberryless)! - Release first minor version. Latest version in site title and virtual module export.

--- a/documentation/vendor/starlight-latest-version/LICENSE
+++ b/documentation/vendor/starlight-latest-version/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-present, trueberryless
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/documentation/vendor/starlight-latest-version/README.md
+++ b/documentation/vendor/starlight-latest-version/README.md
@@ -1,0 +1,15 @@
+# `starlight-latest-version`
+
+Show the latest released version of your package in your Starlight documentation.
+
+## Documentation
+
+Want to get started immediately?
+
+Check out the `starlight-latest-version` getting started guide.
+
+## License
+
+Licensed under the MIT license, Copyright © trueberryless.
+
+See [LICENSE](https://github.com/trueberryless-org/starlight-latest-version/blob/main/LICENSE) for more information.

--- a/documentation/vendor/starlight-latest-version/components/DynamicVersionBadge.astro
+++ b/documentation/vendor/starlight-latest-version/components/DynamicVersionBadge.astro
@@ -1,0 +1,29 @@
+---
+import pluginConfig from "virtual:starlight-latest-version-config";
+import VersionBadge from "./VersionBadge.astro";
+import { Badge } from "@astrojs/starlight/components";
+---
+
+{pluginConfig.showInSiteTitle === "true" && <VersionBadge />}
+{
+  pluginConfig.showInSiteTitle === "deferred" && (
+    <VersionBadge server:defer useCache={true}>
+      <Badge
+        text={"Loading..."}
+        variant="default"
+        size="medium"
+        slot="fallback"
+      />
+    </VersionBadge>
+  )
+}
+
+{(pluginConfig.showInSiteTitle === "true" || pluginConfig.showInSiteTitle === "deferred") && (
+  <style is:global>
+    .title-wrapper {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+  </style>
+)}

--- a/documentation/vendor/starlight-latest-version/components/Version.astro
+++ b/documentation/vendor/starlight-latest-version/components/Version.astro
@@ -1,0 +1,9 @@
+---
+import fetchVersion from "../libs/utils";
+import pluginConfig from "virtual:starlight-latest-version-config";
+
+const version = await fetchVersion(pluginConfig);
+---
+
+{version.versionAvailable && <span>{version.version}</span>}
+{!version.versionAvailable && <span>N/A</span>}

--- a/documentation/vendor/starlight-latest-version/components/VersionBadge.astro
+++ b/documentation/vendor/starlight-latest-version/components/VersionBadge.astro
@@ -1,0 +1,87 @@
+---
+import type { starlightLatestVersionContext } from "../libs/types";
+import { Badge } from "@astrojs/starlight/components";
+import fetchVersion from "../libs/utils";
+import { releasePageUrls } from "../libs/urlBuilder";
+import pluginConfig from "virtual:starlight-latest-version-config";
+
+interface Props {
+  useCache?: boolean;
+}
+
+const { useCache = false } = Astro.props;
+
+let version: starlightLatestVersionContext = {
+  versionAvailable: false,
+};
+if (useCache) {
+  // This setup caches the result in Astro.session for 1 hour.
+  // Call `clearVersionCache` to manually invalidate the cache. 🚀
+  const CACHE_EXPIRATION_MS = 60 * 60 * 1000;
+
+  const cacheKey = `versionCache:${pluginConfig.source.type}:${pluginConfig.source.slug}`;
+  const cachedData = await Astro.session?.get(cacheKey);
+
+  if (cachedData) {
+    const { timestamp, context } = JSON.parse(cachedData);
+    if (Date.now() - timestamp < CACHE_EXPIRATION_MS) {
+      version = context;
+    } else {
+      version = await fetchVersion(pluginConfig);
+      await Astro.session?.set(
+        cacheKey,
+        JSON.stringify({ timestamp: Date.now(), context: version })
+      );
+    }
+  } else {
+    version = await fetchVersion(pluginConfig);
+    await Astro.session?.set(
+      cacheKey,
+      JSON.stringify({ timestamp: Date.now(), context: version })
+    );
+  }
+} else {
+  version = await fetchVersion(pluginConfig);
+}
+
+const sourceUrl = releasePageUrls[pluginConfig.source.type](
+  pluginConfig.source.slug
+);
+---
+
+{
+  version.versionAvailable && (
+    <starlight-latest-version>
+      <a href={sourceUrl} id="starlight-latest-version-link">
+        <Badge
+          text={version.version}
+          variant={pluginConfig.badge.variant}
+          size={pluginConfig.badge.size}
+          id="starlight-latest-version-badge"
+        />
+      </a>
+    </starlight-latest-version>
+  )
+}
+{
+  !version.versionAvailable && (
+    <starlight-latest-version>
+      <a href={sourceUrl} id="starlight-latest-version-link">
+        <Badge
+          text="N/A"
+          variant={pluginConfig.badge.variant}
+          size={pluginConfig.badge.size}
+          id="starlight-latest-version-badge"
+        />
+      </a>
+    </starlight-latest-version>
+  )
+}
+
+<style>
+  #starlight-latest-version-link {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+  }
+</style>

--- a/documentation/vendor/starlight-latest-version/consts/semantic.version.pattern.ts
+++ b/documentation/vendor/starlight-latest-version/consts/semantic.version.pattern.ts
@@ -1,0 +1,2 @@
+export const SEMVER_PATTERN =
+  /^(?:v|[^0-9\s]*@)?v?(?<version>[0-9]+\.[0-9]+\.[0-9]+)(?:-(?<prerelease>[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*))?(?![-.]|[^-\w.])$/;

--- a/documentation/vendor/starlight-latest-version/index.ts
+++ b/documentation/vendor/starlight-latest-version/index.ts
@@ -1,0 +1,71 @@
+import type { StarlightPlugin } from "@astrojs/starlight/types";
+
+import {
+  type starlightLatestVersionConfig,
+  type starlightLatestVersionUserConfig,
+  validateConfig,
+} from "./libs/config";
+import { overrideStarlightComponent } from "./libs/starlight";
+import type { starlightLatestVersionContext } from "./libs/types";
+import { vitePluginstarlightLatestVersionConfig } from "./libs/vite";
+
+export type {
+  starlightLatestVersionConfig,
+  starlightLatestVersionContext,
+  starlightLatestVersionUserConfig,
+};
+
+export default function starlightLatestVersion(
+  userConfig?: starlightLatestVersionUserConfig
+): StarlightPlugin {
+  const config = validateConfig(userConfig);
+
+  return {
+    name: "starlight-latest-version",
+    hooks: {
+      "config:setup"({
+        addIntegration,
+        updateConfig: updateStarlightConfig,
+        config: starlightConfig,
+        logger,
+      }) {
+        updateStarlightConfig({
+          components: {
+            ...starlightConfig.components,
+            ...(config.showInSiteTitle !== "false"
+              ? overrideStarlightComponent(
+                  starlightConfig.components,
+                  logger,
+                  "SiteTitle",
+                  "DynamicVersionBadge"
+                )
+              : {}),
+          },
+        });
+
+        addIntegration({
+          name: "starlight-latest-version-integration",
+          hooks: {
+            "astro:config:setup": ({ updateConfig }) => {
+              updateConfig({
+                vite: {
+                  plugins: [vitePluginstarlightLatestVersionConfig(config)],
+                },
+              });
+            },
+            "astro:config:done": ({ injectTypes }) => {
+              injectTypes({
+                filename: "types.d.ts",
+                content: `declare module "virtual:starlight-latest-version" {
+  export function getLatestVersion(): Promise<
+    import("starlight-latest-version").starlightLatestVersionContext
+  >;
+}`,
+              });
+            },
+          },
+        });
+      },
+    },
+  };
+}

--- a/documentation/vendor/starlight-latest-version/libs/config.ts
+++ b/documentation/vendor/starlight-latest-version/libs/config.ts
@@ -1,0 +1,48 @@
+import { AstroError } from "astro/errors";
+import { z } from "astro/zod";
+
+const configSchema = z.object({
+  source: z.object({
+    type: z.enum(["github", "gitlab", "npm"]).default("npm"),
+    slug: z.string().min(1, "Slug cannot be empty"),
+  }),
+  badge: z
+    .object({
+      variant: z
+        .enum(["default", "note", "danger", "success", "caution", "tip"])
+        .default("default"),
+      size: z.enum(["small", "medium", "large"]).default("medium"),
+    })
+    .prefault({}),
+  showInSiteTitle: z.enum(["false", "true", "deferred"]).default("false"),
+  regexPattern: z.string().optional(),
+});
+
+export function validateConfig(
+  userConfig: unknown
+): starlightLatestVersionConfig {
+  const config = configSchema.safeParse(userConfig);
+
+  if (!config.success) {
+    const errors = config.error.flatten();
+
+    throw new AstroError(
+      `Invalid starlight-latest-version configuration:
+
+      ${errors.formErrors.map((formError) => ` - ${formError}`).join("\n")}
+      ${Object.entries(errors.fieldErrors)
+        .map(
+          ([fieldName, fieldErrors]) =>
+            ` - ${fieldName}: ${fieldErrors.join(" - ")}`
+        )
+        .join("\n")}
+        `,
+      `See the error report above for more informations.\n\nIf you believe this is a bug, please file an issue at https://github.com/trueberryless-org/starlight-latest-version/issues/new`
+    );
+  }
+
+  return config.data;
+}
+
+export type starlightLatestVersionUserConfig = z.input<typeof configSchema>;
+export type starlightLatestVersionConfig = z.output<typeof configSchema>;

--- a/documentation/vendor/starlight-latest-version/libs/starlight.ts
+++ b/documentation/vendor/starlight-latest-version/libs/starlight.ts
@@ -1,0 +1,29 @@
+import type { StarlightUserConfig } from "@astrojs/starlight/types";
+import type { AstroIntegrationLogger } from "astro";
+
+export function overrideStarlightComponent(
+  components: StarlightUserConfig["components"],
+  logger: AstroIntegrationLogger,
+  override: keyof NonNullable<StarlightUserConfig["components"]>,
+  component: string
+) {
+  if (components?.[override]) {
+    logger.warn(
+      `It looks like you already have a \`${override}\` component override in your Starlight configuration.`
+    );
+    logger.warn(
+      `To use \`starlight-latest-version\`, either remove your override or update it to render the content from \`starlight-latest-version/components/${component}.astro\`.`
+    );
+    if (component === "DynamicVersionBadge") {
+      logger.warn(
+        "Notice that the `DynamicVersionBadge` component must be rendered AFTER the original Starlight `SiteTitle` component in the DOM. This ensures proper layout and behavior within the application."
+      );
+    }
+
+    return {};
+  }
+
+  return {
+    [override]: `starlight-latest-version/overrides/${override}.astro`,
+  };
+}

--- a/documentation/vendor/starlight-latest-version/libs/types.ts
+++ b/documentation/vendor/starlight-latest-version/libs/types.ts
@@ -1,0 +1,23 @@
+import { z } from "astro/zod";
+
+// Enum-like structure for the version state
+export const VersionState = z.union([
+  z.object({
+    versionAvailable: z.literal(true),
+    version: z.string(),
+    versionWithoutPrefix: z.string(),
+    versionMajor: z.number(),
+    versionMinor: z.number(),
+    versionPatch: z.number(),
+    prerelease: z.string().optional(),
+    isPrereleaseVersion: z.boolean(),
+    prefix: z.string().optional(),
+    hasVPrefix: z.boolean(),
+    isStableVersion: z.boolean(),
+  }),
+  z.object({
+    versionAvailable: z.literal(false),
+  }),
+]);
+
+export type starlightLatestVersionContext = z.infer<typeof VersionState>;

--- a/documentation/vendor/starlight-latest-version/libs/urlBuilder.ts
+++ b/documentation/vendor/starlight-latest-version/libs/urlBuilder.ts
@@ -1,0 +1,27 @@
+export const releasePageUrls: Record<
+  "github" | "gitlab" | "npm",
+  (slug: string) => string
+> = {
+  github: (slug) => `https://github.com/${slug}/releases`,
+  gitlab: (slug) => `https://gitlab.com/${slug}/-/releases`,
+  npm: (slug) => `https://www.npmjs.com/package/${slug}?activeTab=versions`,
+};
+
+export const latestReleaseApis: Record<
+  "github" | "gitlab" | "npm",
+  (slug: string) => string
+> = {
+  github: (slug) => `https://api.github.com/repos/${slug}/releases/latest`,
+  gitlab: (slug) =>
+    `https://gitlab.com/api/v4/projects/${encodeURIComponent(slug)}/releases`,
+  npm: (slug) => `https://registry.npmjs.org/${slug}/latest`,
+};
+
+export const extractVersion: Record<
+  "github" | "gitlab" | "npm",
+  (data: any) => string | null
+> = {
+  github: (data) => data?.tag_name || null,
+  gitlab: (data) => data?.[0]?.tag_name || null,
+  npm: (data) => data?.version || null,
+};

--- a/documentation/vendor/starlight-latest-version/libs/utils.ts
+++ b/documentation/vendor/starlight-latest-version/libs/utils.ts
@@ -1,0 +1,62 @@
+import { SEMVER_PATTERN } from "../consts/semantic.version.pattern";
+import type { starlightLatestVersionConfig } from "./config";
+import type { starlightLatestVersionContext } from "./types";
+import { extractVersion, latestReleaseApis } from "./urlBuilder";
+
+export default async function fetchVersion(
+  config: starlightLatestVersionConfig
+): Promise<starlightLatestVersionContext> {
+  const apiUrl = latestReleaseApis[config.source.type](config.source.slug);
+
+  try {
+    const data = await fetch(apiUrl).then((response) => {
+      if (!response.ok)
+        throw new Error(`Failed to fetch: ${response.statusText}`);
+      return response.json();
+    });
+
+    const tagName = extractVersion[config.source.type](data);
+    if (!tagName) {
+      return { versionAvailable: false }; // No release available
+    }
+
+    const match = tagName.match(config.regexPattern ?? SEMVER_PATTERN);
+
+    if (!match) {
+      return { versionAvailable: false }; // No valid version found
+    }
+
+    const versionWithoutPrefix = match.groups?.version || "";
+    const [versionMajor = 0, versionMinor = 0, versionPatch = 0] =
+      versionWithoutPrefix.split(".").map(Number);
+
+    const prerelease = match.groups?.prerelease;
+    const isPrereleaseVersion = !!prerelease;
+    const version = isPrereleaseVersion
+      ? `v${versionWithoutPrefix}-${prerelease}`
+      : `v${versionWithoutPrefix}`;
+
+    const prefixMatch = tagName.match(/^(.*?)v?[0-9]/);
+    const prefix = prefixMatch ? prefixMatch[1] : undefined;
+    const hasVPrefix = tagName.startsWith("v") || tagName.includes("@v");
+
+    const context: starlightLatestVersionContext = {
+      versionAvailable: true,
+      version,
+      versionWithoutPrefix,
+      versionPatch,
+      versionMinor,
+      versionMajor,
+      prerelease,
+      isPrereleaseVersion,
+      prefix,
+      hasVPrefix,
+      isStableVersion: !isPrereleaseVersion,
+    };
+
+    return context;
+  } catch (error) {
+    console.error(error);
+    return { versionAvailable: false }; // Fallback: no version available
+  }
+}

--- a/documentation/vendor/starlight-latest-version/libs/vite.ts
+++ b/documentation/vendor/starlight-latest-version/libs/vite.ts
@@ -1,0 +1,54 @@
+import type { ViteUserConfig } from "astro";
+import { fileURLToPath } from "node:url";
+
+import type { starlightLatestVersionConfig } from "..";
+
+export function vitePluginstarlightLatestVersionConfig(
+  config: starlightLatestVersionConfig
+  // context: starlightLatestVersionContext
+): VitePlugin {
+  const fetchVersionPath = fileURLToPath(
+    new URL("./utils.ts", import.meta.url)
+  ).replace(/\\/g, "/");
+
+  const modules = {
+    "virtual:starlight-latest-version-config": `export default ${JSON.stringify(
+      config
+    )}`,
+    "virtual:starlight-latest-version": `
+import fetchVersion from ${JSON.stringify(fetchVersionPath)};
+
+const config = ${JSON.stringify(config)};
+
+export function getLatestVersion() {
+  return fetchVersion(config);
+}
+`,
+  } satisfies Record<string, string>;
+
+  const moduleResolutionMap = Object.fromEntries(
+    (Object.keys(modules) as (keyof typeof modules)[]).map((key) => [
+      resolveVirtualModuleId(key),
+      key,
+    ])
+  );
+
+  return {
+    name: "vite-plugin-starlight-latest-version-config",
+    load(id) {
+      const moduleId = moduleResolutionMap[id];
+      return moduleId ? modules[moduleId] : undefined;
+    },
+    resolveId(id) {
+      return id in modules ? resolveVirtualModuleId(id) : undefined;
+    },
+  };
+}
+
+function resolveVirtualModuleId<TModuleId extends string>(
+  id: TModuleId
+): `\0${TModuleId}` {
+  return `\0${id}`;
+}
+
+type VitePlugin = NonNullable<ViteUserConfig["plugins"]>[number];

--- a/documentation/vendor/starlight-latest-version/overrides/SiteTitle.astro
+++ b/documentation/vendor/starlight-latest-version/overrides/SiteTitle.astro
@@ -1,0 +1,7 @@
+---
+import Default from "@astrojs/starlight/components/SiteTitle.astro";
+import DynamicVersionBadge from "../components/DynamicVersionBadge.astro";
+---
+
+<Default><slot /></Default>
+<DynamicVersionBadge />

--- a/documentation/vendor/starlight-latest-version/package.json
+++ b/documentation/vendor/starlight-latest-version/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "starlight-latest-version",
+  "version": "0.7.0-issue85-getLatestVersion",
+  "description": "Show the latest released version of your package in your Starlight documentation. Vendored from https://github.com/DanielHabenicht/fork.starlight-latest-version (branch starlight-issue-85-feature) to obtain the getLatestVersion virtual module. Replace with the published version once released.",
+  "keywords": [
+    "starlight",
+    "docs",
+    "astro",
+    "version",
+    "latest"
+  ],
+  "homepage": "https://starlight-latest-version.trueberryless.org",
+  "bugs": {
+    "url": "https://github.com/trueberryless-org/starlight-latest-version/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trueberryless-org/starlight-latest-version.git",
+    "directory": "packages/starlight-latest-version"
+  },
+  "license": "MIT",
+  "author": "trueberryless <trueberryless@gmail.com> (https://trueberryless.org)",
+  "type": "module",
+  "exports": {
+    ".": "./index.ts",
+    "./components/DynamicVersionBadge.astro": "./components/DynamicVersionBadge.astro",
+    "./components/Version.astro": "./components/Version.astro",
+    "./components/VersionBadge.astro": "./components/VersionBadge.astro",
+    "./overrides/SiteTitle.astro": "./overrides/SiteTitle.astro",
+    "./package.json": "./package.json"
+  },
+  "peerDependencies": {
+    "@astrojs/starlight": ">=0.38",
+    "astro": "^6.0.4"
+  },
+  "engines": {
+    "node": ">=22.23.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/documentation/vendor/starlight-latest-version/tsconfig.json
+++ b/documentation/vendor/starlight-latest-version/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "astro/tsconfigs/strictest",
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"]
+}

--- a/documentation/vendor/starlight-latest-version/virtual.d.ts
+++ b/documentation/vendor/starlight-latest-version/virtual.d.ts
@@ -1,0 +1,17 @@
+declare module "virtual:starlight-latest-version-config" {
+  const starlightLatestVersionConfig: import("./index").starlightLatestVersionConfig;
+  export default starlightLatestVersionConfig;
+}
+
+declare module "virtual:starlight-latest-version" {
+  /**
+   * Fetch the latest version of the configured source.
+   *
+   * Returns the same context object used internally by the plugin's
+   * components, so you can read `version`, `versionWithoutPrefix`,
+   * `versionMajor` and friends programmatically.
+   */
+  export function getLatestVersion(): Promise<
+    import("./index").starlightLatestVersionContext
+  >;
+}


### PR DESCRIPTION
Replace the hardcoded v0.14.0 download URLs and CLI output in the getting-started guide with values fetched at build time via the getLatestVersion() virtual module from starlight-latest-version.

The plugin's getLatestVersion feature is unpublished, so vendor the feature-branch package under documentation/vendor and reference it via a file: dependency. Swap to a published version once released.