### PR TITLE
fix: remove redundant references in formatting macros

### DIFF
--- a/components/api/src/lib.rs
+++ b/components/api/src/lib.rs
@@ -333,7 +333,7 @@ impl Module for UbiHomePlatform {
                                 match cmd {
                                     PublishedMessage::SensorValueChanged { key, value } => {
                                         let key = api_components_key_id_clone.get(&key).unwrap();
-                                        debug!("SensorValueChanged: {:?}", &value);
+                                        debug!("SensorValueChanged: {:?}", value);
 
                                         tx_clone
                                             .send(ProtoMessage::SensorStateResponse(
@@ -349,7 +349,7 @@ impl Module for UbiHomePlatform {
                                     }
                                     PublishedMessage::BinarySensorValueChanged { key, value } => {
                                         let key = api_components_key_id_clone.get(&key).unwrap();
-                                        debug!("BinarySensorValueChanged: {:?}", &value);
+                                        debug!("BinarySensorValueChanged: {:?}", value);
 
                                         tx_clone
                                             .send(ProtoMessage::BinarySensorStateResponse(
@@ -365,7 +365,7 @@ impl Module for UbiHomePlatform {
                                     }
                                     PublishedMessage::SwitchStateChange { key, state } => {
                                         let key = api_components_key_id_clone.get(&key).unwrap();
-                                        debug!("SwitchStateChanged: {:?}", &state);
+                                        debug!("SwitchStateChanged: {:?}", state);
 
                                         tx_clone
                                             .send(ProtoMessage::SwitchStateResponse(
@@ -387,7 +387,7 @@ impl Module for UbiHomePlatform {
                                         blue,
                                     } => {
                                         let key = api_components_key_id_clone.get(&key).unwrap();
-                                        debug!("LightStateChanged: state={:?}, brightness={:?}, rgb=({:?},{:?},{:?})", &state, &brightness, &red, &green, &blue);
+                                        debug!("LightStateChanged: state={:?}, brightness={:?}, rgb=({:?},{:?},{:?})", state, brightness, red, green, blue);
 
                                         tx_clone
                                             .send(ProtoMessage::LightStateResponse(
@@ -413,7 +413,7 @@ impl Module for UbiHomePlatform {
                                     }
                                     PublishedMessage::NumberValueChanged { key, value } => {
                                         if let Some(key) = api_components_key_id_clone.get(&key) {
-                                            debug!("NumberValueChanged: {:?}", &value);
+                                            debug!("NumberValueChanged: {:?}", value);
 
                                             tx_clone
                                                 .send(ProtoMessage::NumberStateResponse(
@@ -430,7 +430,7 @@ impl Module for UbiHomePlatform {
                                     }
                                     PublishedMessage::TextSensorValueChanged { key, value } => {
                                         if let Some(key) = api_components_key_id_clone.get(&key) {
-                                            debug!("TextSensorValueChanged: {:?}", &value);
+                                            debug!("TextSensorValueChanged: {:?}", value);
 
                                             tx_clone
                                                 .send(ProtoMessage::TextSensorStateResponse(
@@ -446,7 +446,7 @@ impl Module for UbiHomePlatform {
                                         }
                                     }
                                     PublishedMessage::BluetoothProxyMessage(msg) => {
-                                        debug!("BluetoothProxyMessage: {:?}", &msg);
+                                        debug!("BluetoothProxyMessage: {:?}", msg);
                                         #[allow(deprecated)]
                                         let service_data: Vec<BluetoothServiceData> = msg
                                             .service_data

--- a/components/mqtt/src/lib.rs
+++ b/components/mqtt/src/lib.rs
@@ -472,7 +472,7 @@ impl Module for UbiHomePlatform {
                                     }
 
                                     if let Some(msg) = msg {
-                                        debug!("Received on '{}': {:?}", topic, &msg);
+                                        debug!("Received on '{}': {:?}", topic, msg);
                                         sender.send(msg).unwrap();
                                     }
                                 }

--- a/components/shell/src/lib.rs
+++ b/components/shell/src/lib.rs
@@ -374,7 +374,7 @@ impl Module for UbiHomePlatform {
 
                                     match output {
                                         Ok(output) => {
-                                            debug!("Switch {} output: {}", key, &output);
+                                            debug!("Switch {} output: {}", key, output);
                                             let value = if output.trim().to_lowercase() == "true" {
                                                 true
                                             } else if output.trim().to_lowercase() == "false" {
@@ -497,7 +497,7 @@ impl Module for UbiHomePlatform {
 
                                     match output {
                                         Ok(output) => {
-                                            debug!("Light {} state output: {}", key, &output);
+                                            debug!("Light {} state output: {}", key, output);
                                             let value = if output.trim().to_lowercase() == "true" {
                                                 true
                                             } else if output.trim().to_lowercase() == "false" {
@@ -583,7 +583,7 @@ impl Module for UbiHomePlatform {
                             // TODO: Handle long running commands (e.g. newline per value) and multivalued outputs (e.g. json)
                             match output {
                                 Ok(output) => {
-                                    debug!("Sensor {} output: {}", key, &output);
+                                    debug!("Sensor {} output: {}", key, output);
                                     let value = output;
 
                                     _ = cloned_sender.send(ChangedMessage::SensorValueChange {
@@ -630,7 +630,7 @@ impl Module for UbiHomePlatform {
                             .await;
                             match output {
                                 Ok(output) => {
-                                    debug!("Switch {} output: {}", key, &output);
+                                    debug!("Switch {} output: {}", key, output);
                                     let value = if output.trim().to_lowercase() == "true" {
                                         true
                                     } else if output.trim().to_lowercase() == "false" {
@@ -731,7 +731,7 @@ impl Module for UbiHomePlatform {
                             .await;
                             match output {
                                 Ok(output) => {
-                                    debug!("Light {} state: {}", key, &output);
+                                    debug!("Light {} state: {}", key, output);
                                     let value = if output.trim().to_lowercase() == "true" {
                                         true
                                     } else if output.trim().to_lowercase() == "false" {
@@ -792,7 +792,7 @@ impl Module for UbiHomePlatform {
                             .await;
                             match output {
                                 Ok(output) => {
-                                    debug!("Number {} state: {}", key, &output);
+                                    debug!("Number {} state: {}", key, output);
                                     match output.trim().parse::<f32>() {
                                         Ok(value) => {
                                             _ = cloned_sender.send(
@@ -850,7 +850,7 @@ impl Module for UbiHomePlatform {
                             .await;
                             match output {
                                 Ok(output) => {
-                                    debug!("Text Sensor {} state: {}", key, &output);
+                                    debug!("Text Sensor {} state: {}", key, output);
                                     _ = cloned_sender.send(ChangedMessage::TextSensorValueChange {
                                         key: key.clone(),
                                         value: output.trim().to_string(),

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -88,7 +88,7 @@ pub(crate) fn run(
     }
 
     let platforms = get_platforms_from_config(&config_string);
-    debug!("Configured modules: {:?}", &platforms);
+    debug!("Configured modules: {:?}", platforms);
 
     if sentry::Hub::current().client().is_some() {
         sentry::configure_scope(|scope| {

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,8 +18,8 @@ fn only_allow_configured_platforms(value: &String, context: &BaseConfigContext) 
         if !allowed_platforms.contains(value) {
             return Err(garde::Error::new(format!(
                 "Platform '{}' is not configured in the configuration file. Allowed platforms are: {}",
-                &value,
-                &allowed_platforms.join(", ")
+                value,
+                allowed_platforms.join(", ")
             )));
         }
     }


### PR DESCRIPTION
Clippy 1.97 flags useless_borrows_in_formatting on `&arg` passed to format!/debug! macros, breaking `make lint` with -D warnings.