### PR TITLE
fix: update api module to esphome-native-api 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "esphome-native-api"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5415368ebae47f3823d77fc40f457a7f7f4dbb416e8611e6127ec8d6280159"
+checksum = "4251b5fa1b13310513b7165234061266f8c25ab1f6801e5a392d3b8372bdf7e8"
 dependencies = [
  "base64",
  "byteorder",
@@ -1405,6 +1405,7 @@ dependencies = [
  "noise-protocol",
  "noise-rust-crypto",
  "prost",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/components/api/Cargo.toml
+++ b/components/api/Cargo.toml
@@ -11,7 +11,7 @@ tokio = { version = "1", features = ["full"] }
 ubihome-core = { path = "../core", features = ["ip", "validation"] }
 serde-saphyr = { version = "0.0.26", features = ["garde", "miette"] }
 duration-str = "0.16.1"
-esphome-native-api = "2.1.0"
+esphome-native-api = "3.0.0"
 # esphome-native-api = { path = "../../../esphome-native-api/" }
 whoami = "1.6.0"
 garde = { version = "0.22.1", features = ["serde"] }

--- a/components/api/src/lib.rs
+++ b/components/api/src/lib.rs
@@ -48,22 +48,28 @@ use ubihome_core::constants::is_readable_string_option;
 ///
 /// - `debug`: routine lifecycle events — the peer disconnected or never
 ///   completed a handshake (e.g. a port probe). Not a problem.
-/// - `error`: the application itself is at fault and an operator can fix it —
-///   a bad configuration or a background task that died unexpectedly.
-/// - `warn`: everything else is caused by the peer or the transport and the
-///   application cannot prevent it (wrong encryption key, protocol mismatch,
-///   malformed/undecodable frames, unexpected I/O). Worth noting, not our fault.
+/// - `warn`: the specific peer- or transport-caused problems we recognize and
+///   the application cannot prevent (wrong encryption key, protocol mismatch,
+///   malformed/undecodable frames). Worth noting, but not our fault.
+/// - `error`: everything else. Default to error so any unexpected fault is
+///   visible; downgrade to `warn` only for cases we have explicitly classified.
 fn log_api_error(context: &str, err: &Error) {
     match err {
         Error::Disconnected(_)
         | Error::Handshake(HandshakeError::NoData | HandshakeError::Aborted) => {
             debug!("{context}: {err}");
         }
-        Error::Config(_) | Error::TaskFailed => {
-            error!("{context}: {err}");
+        Error::Frame(_)
+        | Error::Handshake(
+            HandshakeError::InvalidMarker(_)
+            | HandshakeError::EncryptionProtocolMismatch(_)
+            | HandshakeError::MalformedFrame
+            | HandshakeError::MacFailure,
+        ) => {
+            warn!("{context}: {err}");
         }
         _ => {
-            warn!("{context}: {err}");
+            error!("{context}: {err}");
         }
     }
 }

--- a/components/api/src/lib.rs
+++ b/components/api/src/lib.rs
@@ -1,26 +1,26 @@
 use esphome_native_api::esphomeapi::EspHomeApi;
 use esphome_native_api::hash::hash_fnv1;
 use esphome_native_api::parser::ProtoMessage;
-use esphome_native_api::proto::version_2026_6_2::BinarySensorStateResponse;
-use esphome_native_api::proto::version_2026_6_2::BluetoothLeAdvertisementResponse;
-use esphome_native_api::proto::version_2026_6_2::BluetoothServiceData;
-use esphome_native_api::proto::version_2026_6_2::EntityCategory;
-use esphome_native_api::proto::version_2026_6_2::LightStateResponse;
-use esphome_native_api::proto::version_2026_6_2::ListEntitiesBinarySensorResponse;
-use esphome_native_api::proto::version_2026_6_2::ListEntitiesButtonResponse;
-use esphome_native_api::proto::version_2026_6_2::ListEntitiesDoneResponse;
-use esphome_native_api::proto::version_2026_6_2::ListEntitiesLightResponse;
-use esphome_native_api::proto::version_2026_6_2::ListEntitiesNumberResponse;
-use esphome_native_api::proto::version_2026_6_2::ListEntitiesSensorResponse;
-use esphome_native_api::proto::version_2026_6_2::ListEntitiesSwitchResponse;
-use esphome_native_api::proto::version_2026_6_2::ListEntitiesTextSensorResponse;
-use esphome_native_api::proto::version_2026_6_2::NumberStateResponse;
-use esphome_native_api::proto::version_2026_6_2::SensorLastResetType;
-use esphome_native_api::proto::version_2026_6_2::SensorStateClass;
-use esphome_native_api::proto::version_2026_6_2::SensorStateResponse;
-use esphome_native_api::proto::version_2026_6_2::SubscribeLogsResponse;
-use esphome_native_api::proto::version_2026_6_2::SwitchStateResponse;
-use esphome_native_api::proto::version_2026_6_2::TextSensorStateResponse;
+use esphome_native_api::proto::BinarySensorStateResponse;
+use esphome_native_api::proto::BluetoothLeAdvertisementResponse;
+use esphome_native_api::proto::BluetoothServiceData;
+use esphome_native_api::proto::EntityCategory;
+use esphome_native_api::proto::LightStateResponse;
+use esphome_native_api::proto::ListEntitiesBinarySensorResponse;
+use esphome_native_api::proto::ListEntitiesButtonResponse;
+use esphome_native_api::proto::ListEntitiesDoneResponse;
+use esphome_native_api::proto::ListEntitiesLightResponse;
+use esphome_native_api::proto::ListEntitiesNumberResponse;
+use esphome_native_api::proto::ListEntitiesSensorResponse;
+use esphome_native_api::proto::ListEntitiesSwitchResponse;
+use esphome_native_api::proto::ListEntitiesTextSensorResponse;
+use esphome_native_api::proto::NumberStateResponse;
+use esphome_native_api::proto::SensorLastResetType;
+use esphome_native_api::proto::SensorStateClass;
+use esphome_native_api::proto::SensorStateResponse;
+use esphome_native_api::proto::SubscribeLogsResponse;
+use esphome_native_api::proto::SwitchStateResponse;
+use esphome_native_api::proto::TextSensorStateResponse;
 use log::debug;
 use log::info;
 use serde::{Deserialize, Deserializer};
@@ -98,7 +98,7 @@ impl Module for UbiHomePlatform {
         let ip = get_ip_address().unwrap();
         let mac = get_network_mac_address(ip).unwrap();
 
-        let server_base = EspHomeApi::builder()
+        let server_base = match EspHomeApi::builder()
             .api_version_major(1)
             .api_version_minor(42)
             .encryption_key_opt(
@@ -135,7 +135,15 @@ impl Module for UbiHomePlatform {
                     .clone()
                     .unwrap_or("".to_string()),
             )
-            .build();
+            .build()
+        {
+            Ok(server) => server,
+            Err(err) => {
+                return Box::pin(async move {
+                    Err(Box::new(err) as Box<dyn std::error::Error>)
+                });
+            }
+        };
 
         let config = self.config.clone();
         // let mut api_components = self.components.();
@@ -322,8 +330,8 @@ impl Module for UbiHomePlatform {
                 tokio::spawn({
                     async move {
                         debug!("Accepted request from {}", socket.peer_addr().unwrap());
-                        let (tx, mut rx) = match server.start(socket).await {
-                            Ok(handles) => handles,
+                        let connection = match server.start(socket).await {
+                            Ok(connection) => connection,
                             Err(err) => {
                                 // A client (or the test port probe) may connect and
                                 // disconnect without completing the handshake. Drop
@@ -333,6 +341,8 @@ impl Module for UbiHomePlatform {
                             }
                         };
 
+                        let tx = connection.sender();
+                        let mut rx = connection.receiver();
                         let tx_clone = tx.clone();
 
                         // Send Messages
@@ -695,7 +705,7 @@ impl Module for UbiHomePlatform {
 
 #[cfg(test)]
 mod tests {
-    use esphome_native_api::proto::version_2026_6_2::ListEntitiesLightResponse;
+    use esphome_native_api::proto::ListEntitiesLightResponse;
 
     use super::*;
 

--- a/components/api/src/lib.rs
+++ b/components/api/src/lib.rs
@@ -21,8 +21,12 @@ use esphome_native_api::proto::SensorStateResponse;
 use esphome_native_api::proto::SubscribeLogsResponse;
 use esphome_native_api::proto::SwitchStateResponse;
 use esphome_native_api::proto::TextSensorStateResponse;
+use esphome_native_api::Error;
+use esphome_native_api::HandshakeError;
 use log::debug;
+use log::error;
 use log::info;
+use log::warn;
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -39,6 +43,30 @@ use ubihome_core::{
 };
 
 use ubihome_core::constants::is_readable_string_option;
+
+/// Log an API connection error at a level that reflects who can act on it.
+///
+/// - `debug`: routine lifecycle events — the peer disconnected or never
+///   completed a handshake (e.g. a port probe). Not a problem.
+/// - `error`: the application itself is at fault and an operator can fix it —
+///   a bad configuration or a background task that died unexpectedly.
+/// - `warn`: everything else is caused by the peer or the transport and the
+///   application cannot prevent it (wrong encryption key, protocol mismatch,
+///   malformed/undecodable frames, unexpected I/O). Worth noting, not our fault.
+fn log_api_error(context: &str, err: &Error) {
+    match err {
+        Error::Disconnected(_)
+        | Error::Handshake(HandshakeError::NoData | HandshakeError::Aborted) => {
+            debug!("{context}: {err}");
+        }
+        Error::Config(_) | Error::TaskFailed => {
+            error!("{context}: {err}");
+        }
+        _ => {
+            warn!("{context}: {err}");
+        }
+    }
+}
 
 #[derive(Clone, Deserialize, Debug, Validate)]
 #[serde(deny_unknown_fields)]
@@ -139,9 +167,7 @@ impl Module for UbiHomePlatform {
         {
             Ok(server) => server,
             Err(err) => {
-                return Box::pin(async move {
-                    Err(Box::new(err) as Box<dyn std::error::Error>)
-                });
+                return Box::pin(async move { Err(Box::new(err) as Box<dyn std::error::Error>) });
             }
         };
 
@@ -333,10 +359,7 @@ impl Module for UbiHomePlatform {
                         let connection = match server.start(socket).await {
                             Ok(connection) => connection,
                             Err(err) => {
-                                // A client (or the test port probe) may connect and
-                                // disconnect without completing the handshake. Drop
-                                // the connection instead of crashing the worker.
-                                debug!("Failed to start API connection: {err}");
+                                log_api_error("Failed to start API connection", &err);
                                 return;
                             }
                         };
@@ -694,8 +717,14 @@ impl Module for UbiHomePlatform {
                                     }
                                 }
                             }
-                            debug!("Connection closed or error");
                         });
+
+                        // A peer going away is the normal way a session ends;
+                        // anything else is classified by log_api_error.
+                        match connection.wait().await {
+                            Ok(()) => debug!("API connection closed"),
+                            Err(err) => log_api_error("API connection ended", &err),
+                        }
                     }
                 });
             }


### PR DESCRIPTION
Migrate the api module to the typed-errors/Connection API introduced in esphome-native-api 3.0.0:
- build() now returns a Result (encryption keys validated at build time)
- start() returns a Connection handle; use sender()/receiver() instead of the previous (tx, rx) tuple
- proto types are re-exported at proto::* rather than proto::version_2026_6_2::*