### PR TITLE
fix: reconnect sendspin and supervise tasks for graceful shutdown

### DIFF
--- a/components/sendspin/src/lib.rs
+++ b/components/sendspin/src/lib.rs
@@ -307,7 +307,15 @@ impl Module for UbiHomePlatform {
             // until UbiHome is restarted.
             let initial_backoff = std::time::Duration::from_secs(1);
             let max_backoff = std::time::Duration::from_secs(30);
+            // A connection must stay up at least this long to be treated as stable.
+            // Connections that drop sooner keep escalating the backoff, so a server
+            // that accepts the connection and then drops the session immediately is
+            // not reconnected roughly once per second.
+            let stable_connection = std::time::Duration::from_secs(10);
             let mut backoff = initial_backoff;
+            // Whether a player has ever been initialized. Used to avoid clearing a
+            // player that does not exist yet (e.g. on the very first connection).
+            let mut player_ever_initialized = false;
 
             loop {
                 info!("Connecting to Sendspin server at {}...", server);
@@ -347,9 +355,7 @@ impl Module for UbiHomePlatform {
                     }
                 };
                 info!("Connected to Sendspin server at {}", server);
-                // Reset backoff after a successful connection so a brief blip
-                // reconnects quickly.
-                backoff = initial_backoff;
+                let connected_at = std::time::Instant::now();
 
                 let conn = client.split();
                 let mut message_rx = conn.messages;
@@ -360,8 +366,11 @@ impl Module for UbiHomePlatform {
 
                 info!("Waiting for stream to start...");
 
-                // Clear any audio left buffered from a previous connection.
-                let _ = player_tx.send(PlayerCommand::Clear);
+                // Clear any audio left buffered from a previous connection. Skip it
+                // until a player exists, otherwise this warns on every startup.
+                if player_ever_initialized {
+                    let _ = player_tx.send(PlayerCommand::Clear);
+                }
 
                 // Message handling variables (reset for each connection)
                 let mut decoder: Option<PcmDecoder> = None;
@@ -604,6 +613,7 @@ impl Module for UbiHomePlatform {
                                                 Arc::clone(&clock_sync),
                                             ));
                                             player_initialized = true;
+                                            player_ever_initialized = true;
                                         }
 
                                         let buffer = AudioBuffer {
@@ -627,11 +637,19 @@ impl Module for UbiHomePlatform {
                     }
                 }
 
+                // Reset the backoff only if the connection stayed up long enough to
+                // be considered stable, so a brief blip reconnects quickly while a
+                // connection that drops immediately keeps backing off.
+                if connected_at.elapsed() >= stable_connection {
+                    backoff = initial_backoff;
+                }
                 warn!(
                     "Sendspin connection to {} closed; reconnecting in {:?}",
                     server, backoff
                 );
-                let _ = player_tx.send(PlayerCommand::Clear);
+                if player_ever_initialized {
+                    let _ = player_tx.send(PlayerCommand::Clear);
+                }
                 tokio::time::sleep(backoff).await;
                 backoff = (backoff * 2).min(max_backoff);
             }

--- a/components/sendspin/src/lib.rs
+++ b/components/sendspin/src/lib.rs
@@ -1,7 +1,7 @@
 use core::panic;
 use cpal::traits::{DeviceTrait, HostTrait};
 use cpal::Device;
-use log::{debug, error, info, trace};
+use log::{debug, error, info, trace, warn};
 use sendspin::audio::decode::{Decoder, PcmDecoder, PcmEndian};
 use sendspin::audio::{AudioBuffer, AudioFormat, Codec, SyncedPlayer, SyncedPlayerConfig};
 use sendspin::protocol::messages::{
@@ -35,8 +35,6 @@ enum PlayerCommand {
     SetVolume(u8),
     /// Mute or unmute the player
     SetMute(bool),
-    /// Shutdown the player thread
-    Shutdown,
 }
 
 fn env_u64(key: &str, default: u64) -> u64 {
@@ -219,54 +217,6 @@ impl Module for UbiHomePlatform {
         };
 
         Box::pin(async move {
-            let test = ProtocolClientBuilder::builder()
-                .client_id(id.clone())
-                .name(name.clone())
-                .player_v1_support(PlayerV1Support {
-                    supported_formats: vec![AudioFormatSpec {
-                        codec: "pcm".to_string(),
-                        channels: 2,
-                        sample_rate,
-                        bit_depth,
-                    }],
-                    buffer_capacity: 50 * 1024 * 1024, // 50 MB
-                    supported_commands: vec!["volume".to_string(), "mute".to_string()],
-                })
-                .initial_player_state(PlayerState {
-                    volume: Some(100),
-                    muted: Some(false),
-                    static_delay_ms: Some(0),
-                    supported_commands: None,
-                    min_buffer_ms: None,
-                    required_lead_time_ms: None,
-                })
-                .build();
-
-            let client = test.connect(&server).await.unwrap();
-            debug!("Connected!");
-            // info!("Connecting to {}...", server);
-            // let request = server.into_client_request().unwrap();
-            // let client = ProtocolClient::connect(request, hello).await.unwrap();
-            // info!("Connected!");
-
-            let conn = client.split();
-            let mut message_rx = conn.messages;
-            let mut audio_rx = conn.audio;
-            let clock_sync = conn.clock_sync;
-            let sender = conn.sender;
-            let _guard = conn.guard;
-
-            // Send immediate initial clock sync
-            // let client_transmitted = SystemTime::now()
-            //     .duration_since(UNIX_EPOCH)
-            //     .unwrap()
-            //     .as_micros() as i64;
-            // let time_msg = Message::ClientTime(ClientTime { client_transmitted });
-            // ws_tx.send_message(time_msg).await.unwrap();
-            info!("Sent initial client/time for clock sync");
-
-            info!("Waiting for stream to start...");
-
             // Configuration from environment variables
             let start_buffer_ms = env_u64("SS_PLAY_START_BUFFER_MS", 500);
             let log_lead = env_bool("SS_LOG_LEAD");
@@ -275,7 +225,9 @@ impl Module for UbiHomePlatform {
                 start_buffer_ms, log_lead
             );
 
-            // Create a channel for sending commands to the audio player thread
+            // Create a channel for sending commands to the audio player thread.
+            // The player thread outlives individual server connections, so it is
+            // created once, before the reconnect loop.
             let (player_tx, player_rx) = std::sync::mpsc::channel::<PlayerCommand>();
 
             // Spawn a dedicated thread for audio playback (SyncedPlayer is not Send)
@@ -344,280 +296,345 @@ impl Module for UbiHomePlatform {
                                 log::warn!("Player not initialized yet, cannot set mute");
                             }
                         }
-                        PlayerCommand::Shutdown => {
-                            break;
-                        }
                     }
                 }
                 debug!("Audio player thread exited");
             });
 
-            // Message handling variables
-            let mut decoder: Option<PcmDecoder> = None;
-            let mut audio_format: Option<AudioFormat> = None;
-            let mut endian_locked: Option<PcmEndian> = None; // Auto-detect on first chunk
-            let mut buffered_duration_us: u64 = 0; // Track buffered audio duration in microseconds
-            let mut playback_started = false; // Track if we've started playback
-            let mut first_chunk_logged = false; // Track if we've logged the first chunk
-            let mut player_initialized = false; // Track if player has been initialized
+            // Reconnect loop: a Sendspin connection can drop silently (server
+            // restart, network blip, idle timeout). Reconnect with exponential
+            // backoff instead of exiting the module, which would drop this player
+            // until UbiHome is restarted.
+            let initial_backoff = std::time::Duration::from_secs(1);
+            let max_backoff = std::time::Duration::from_secs(30);
+            let mut backoff = initial_backoff;
 
             loop {
-                // Process messages and audio chunks concurrently
-                tokio::select! {
-                    Some(msg) = message_rx.recv() => {
-                        match msg {
-                            Message::StreamStart(stream_start) => {
-                                if let Some(ref player_config) = stream_start.player {
-                                    debug!(
-                                        "Stream starting: codec='{}' {}Hz {}ch {}bit",
-                                        player_config.codec,
-                                        player_config.sample_rate,
-                                        player_config.channels,
-                                        player_config.bit_depth
-                                    );
+                info!("Connecting to Sendspin server at {}...", server);
+                let test = ProtocolClientBuilder::builder()
+                    .client_id(id.clone())
+                    .name(name.clone())
+                    .player_v1_support(PlayerV1Support {
+                        supported_formats: vec![AudioFormatSpec {
+                            codec: "pcm".to_string(),
+                            channels: 2,
+                            sample_rate,
+                            bit_depth,
+                        }],
+                        buffer_capacity: 50 * 1024 * 1024, // 50 MB
+                        supported_commands: vec!["volume".to_string(), "mute".to_string()],
+                    })
+                    .initial_player_state(PlayerState {
+                        volume: Some(100),
+                        muted: Some(false),
+                        static_delay_ms: Some(0),
+                        supported_commands: None,
+                        min_buffer_ms: None,
+                        required_lead_time_ms: None,
+                    })
+                    .build();
 
-                                    // Validate codec before proceeding
-                                    if player_config.codec != "pcm" {
-                                        error!("ERROR: Unsupported codec '{}' - only 'pcm' is supported!", player_config.codec);
-                                        error!("Server is sending compressed audio that we can't decode!");
-                                        continue;
-                                    }
+                let client = match test.connect(&server).await {
+                    Ok(client) => client,
+                    Err(e) => {
+                        error!(
+                            "Failed to connect to Sendspin server at {}: {}. Retrying in {:?}",
+                            server, e, backoff
+                        );
+                        tokio::time::sleep(backoff).await;
+                        backoff = (backoff * 2).min(max_backoff);
+                        continue;
+                    }
+                };
+                info!("Connected to Sendspin server at {}", server);
+                // Reset backoff after a successful connection so a brief blip
+                // reconnects quickly.
+                backoff = initial_backoff;
 
-                                    if player_config.bit_depth != 16 && player_config.bit_depth != 24 {
-                                        error!("ERROR: Unsupported bit depth {} - only 16 or 24-bit PCM supported!", player_config.bit_depth);
-                                        continue;
-                                    }
+                let conn = client.split();
+                let mut message_rx = conn.messages;
+                let mut audio_rx = conn.audio;
+                let clock_sync = conn.clock_sync;
+                let sender = conn.sender;
+                let _guard = conn.guard;
 
-                                    audio_format = Some(AudioFormat {
-                                        codec: Codec::Pcm,
-                                        sample_rate: player_config.sample_rate,
-                                        channels: player_config.channels,
-                                        bit_depth: player_config.bit_depth,
-                                        codec_header: None,
-                                    });
+                info!("Waiting for stream to start...");
 
-                                    // Decoder will be created on first chunk after auto-detecting endianness
-                                    decoder = None;
-                                    endian_locked = None;
-                                    buffered_duration_us = 0; // Reset on new stream
-                                    playback_started = false;
-                                    first_chunk_logged = false; // Reset for new stream
-                                    debug!("Waiting for first audio chunk to auto-detect endianness...");
-                                } else {
-                                    debug!("Received stream/start without player config");
-                                }
-                            }
-                            Message::ServerTime(server_time) => {
-                                // Get t4 (client receive time) in Unix microseconds
-                                let t4 = SystemTime::now()
-                                    .duration_since(UNIX_EPOCH)
-                                    .unwrap()
-                                    .as_micros() as i64;
+                // Clear any audio left buffered from a previous connection.
+                let _ = player_tx.send(PlayerCommand::Clear);
 
-                                // Update clock sync with all four timestamps
-                                let t1 = server_time.client_transmitted;
-                                let t2 = server_time.server_received;
-                                let t3 = server_time.server_transmitted;
+                // Message handling variables (reset for each connection)
+                let mut decoder: Option<PcmDecoder> = None;
+                let mut audio_format: Option<AudioFormat> = None;
+                let mut endian_locked: Option<PcmEndian> = None; // Auto-detect on first chunk
+                let mut buffered_duration_us: u64 = 0; // Track buffered audio duration in microseconds
+                let mut playback_started = false; // Track if we've started playback
+                let mut first_chunk_logged = false; // Track if we've logged the first chunk
+                let mut player_initialized = false; // Track if player has been initialized
 
-                                clock_sync.lock().update(t1, t2, t3, t4);
+                loop {
+                    // Process messages and audio chunks concurrently
+                    tokio::select! {
+                        Some(msg) = message_rx.recv() => {
+                            match msg {
+                                Message::StreamStart(stream_start) => {
+                                    if let Some(ref player_config) = stream_start.player {
+                                        debug!(
+                                            "Stream starting: codec='{}' {}Hz {}ch {}bit",
+                                            player_config.codec,
+                                            player_config.sample_rate,
+                                            player_config.channels,
+                                            player_config.bit_depth
+                                        );
 
-                                // Log sync quality
-                                let sync = clock_sync.lock();
-                                if let Some(rtt) = sync.rtt_micros() {
-                                    let quality = sync.quality();
-                                    debug!(
-                                        "Clock sync updated: RTT={:.2}ms, quality={:?}",
-                                        rtt as f64 / 1000.0,
-                                        quality
-                                    );
-                                }
-                            }
-                            Message::StreamEnd(stream_end) => {
-                                debug!("Stream ended: {:?}", stream_end.roles);
-                                let _ = player_tx.send(PlayerCommand::Clear);
-                                buffered_duration_us = 0;
-                                playback_started = false;
-                                first_chunk_logged = false;
-                                player_initialized = false;
-                            }
-                            Message::StreamClear(stream_clear) => {
-                                debug!("Stream cleared: {:?}", stream_clear.roles);
-                                let _ = player_tx.send(PlayerCommand::Clear);
-                                buffered_duration_us = 0;
-                                playback_started = false;
-                                first_chunk_logged = false;
-                                player_initialized = false;
-                            }
-                            Message::ServerCommand(cmd) => {
-                                // debug!("Received server command: {}", );
-                                // Set Volume
-                                if !player_initialized {
-                                    log::warn!("Received server command before player initialized: {:?}", cmd);
-                                    continue;
-                                }
-                                match cmd.player {
-                                    None => {
-                                        log::warn!("Received server command without player field: {:?}", cmd);
-                                        continue;
-                                    }
-                                    Some(player) => {
-                                        match player.command {
-                                            PlayerCommandType::Volume => {
-                                                match player.volume {
-                                                    None => {
-                                                        log::warn!("Received server command without volume field");
-                                                    }
-                                                    Some(vol) => {
-                                                        info!("Setting player volume to {}", vol);
-                                                        let _ = player_tx.send(PlayerCommand::SetVolume(vol));
-                                                    }
-                                                }
-                                            }
-                                            PlayerCommandType::Mute => {
-                                                match player.mute {
-                                                    None => {
-                                                        log::warn!("Received server command without muted field");
-                                                    }
-                                                    Some(mute) => {
-                                                        log::info!("Received mute command: {}", mute);
-                                                        let _ = player_tx.send(PlayerCommand::SetMute(mute));
-                                                        sender.send_message(Message::ClientState(
-                                                            ClientState {
-                                                                state: None,
-                                                                player: Some(PlayerState {
-                                                                    volume: None,
-                                                                    muted: Some(mute),
-                                                                    static_delay_ms: None,
-                                                                    supported_commands: None,
-                                                                    required_lead_time_ms: None,
-                                                                    min_buffer_ms: None
-                                                                }),
-                                                            }
-                                                        )).await.unwrap();
-                                                    }
-                                                }
-                                            }
-                                            _ => {
-                                                debug!("Received unsupported server command: {:?}", player.command);
-                                                continue;
-                                            }
+                                        // Validate codec before proceeding
+                                        if player_config.codec != "pcm" {
+                                            error!("ERROR: Unsupported codec '{}' - only 'pcm' is supported!", player_config.codec);
+                                            error!("Server is sending compressed audio that we can't decode!");
+                                            continue;
                                         }
 
+                                        if player_config.bit_depth != 16 && player_config.bit_depth != 24 {
+                                            error!("ERROR: Unsupported bit depth {} - only 16 or 24-bit PCM supported!", player_config.bit_depth);
+                                            continue;
+                                        }
+
+                                        audio_format = Some(AudioFormat {
+                                            codec: Codec::Pcm,
+                                            sample_rate: player_config.sample_rate,
+                                            channels: player_config.channels,
+                                            bit_depth: player_config.bit_depth,
+                                            codec_header: None,
+                                        });
+
+                                        // Decoder will be created on first chunk after auto-detecting endianness
+                                        decoder = None;
+                                        endian_locked = None;
+                                        buffered_duration_us = 0; // Reset on new stream
+                                        playback_started = false;
+                                        first_chunk_logged = false; // Reset for new stream
+                                        debug!("Waiting for first audio chunk to auto-detect endianness...");
+                                    } else {
+                                        debug!("Received stream/start without player config");
                                     }
                                 }
-                            }
-                            _ => {
-                                debug!("Received message: {:?}", msg);
-                            }
-                        }
-                    }
-                    Some(chunk) = audio_rx.recv() => {
-                        // Log first chunk bytes for diagnostics
-                        if !first_chunk_logged {
-                            let preview_len = chunk.data.len().min(32);
-                            let hex_string = chunk.data[..preview_len]
-                                .iter()
-                                .map(|b| format!("{:02X}", b))
-                                .collect::<Vec<_>>()
-                                .join(" ");
-                            debug!("First {} bytes (hex): {}", preview_len, hex_string);
-                            first_chunk_logged = true;
-                        }
+                                Message::ServerTime(server_time) => {
+                                    // Get t4 (client receive time) in Unix microseconds
+                                    let t4 = SystemTime::now()
+                                        .duration_since(UNIX_EPOCH)
+                                        .unwrap()
+                                        .as_micros() as i64;
 
-                        if let Some(ref fmt) = audio_format {
-                            // Frame sanity check
-                            let bytes_per_sample = match fmt.bit_depth {
-                                16 => 2,
-                                24 => 3,
-                                _ => {
-                                    error!("Unsupported bit depth: {}", fmt.bit_depth);
-                                    continue;
-                                }
-                            } as usize;
-                            let frame_size = bytes_per_sample * fmt.channels as usize;
+                                    // Update clock sync with all four timestamps
+                                    let t1 = server_time.client_transmitted;
+                                    let t2 = server_time.server_received;
+                                    let t3 = server_time.server_transmitted;
 
-                            if chunk.data.len() % frame_size != 0 {
-                                error!(
-                                    "BAD FRAME: {} bytes not multiple of frame size {} ({}-bit, {}ch)",
-                                    chunk.data.len(), frame_size, fmt.bit_depth, fmt.channels
-                                );
-                                continue; // Don't decode garbage
-                            }
+                                    clock_sync.lock().update(t1, t2, t3, t4);
 
-                            // One-time endianness setup on first chunk
-                            // Per spec: macOS and most systems use Little-Endian PCM
-                            // Only use Big-Endian if explicitly signaled by server
-                            if endian_locked.is_none() {
-                                // Default to Little-Endian (standard for macOS/Windows/Linux)
-                                let endian = PcmEndian::Little;
-                                endian_locked = Some(endian);
-                                decoder = Some(PcmDecoder::with_endian(fmt.bit_depth, endian));
-                                debug!("Using Little-Endian PCM (standard for modern systems)");
-                            }
-                        }
-
-                        if let (Some(ref dec), Some(ref fmt)) = (&decoder, &audio_format) {
-                            match dec.decode(&chunk.data) {
-                                Ok(samples) => {
-                                    // Calculate chunk duration in microseconds
-                                    // samples.len() includes all channels
-                                    let frames = samples.len() / fmt.channels as usize;
-                                    let duration_micros = (frames as u64 * 1_000_000) / fmt.sample_rate as u64;
-                                    // Track buffered duration
-                                    buffered_duration_us += duration_micros;
-
-                                    // Check if we've buffered enough to start playback
-                                    if !playback_started && buffered_duration_us >= start_buffer_ms * 1000 {
-                                        playback_started = true;
+                                    // Log sync quality
+                                    let sync = clock_sync.lock();
+                                    if let Some(rtt) = sync.rtt_micros() {
+                                        let quality = sync.quality();
                                         debug!(
-                                            "Prebuffering complete ({:.1}ms buffered), starting playback!",
-                                            buffered_duration_us as f64 / 1000.0
+                                            "Clock sync updated: RTT={:.2}ms, quality={:?}",
+                                            rtt as f64 / 1000.0,
+                                            quality
                                         );
                                     }
-
-                                    // Track and log lead time
-                                    if log_lead {
-                                        trace!(
-                                            "Enqueued chunk ts={} buffered={:.1}ms len={} bytes",
-                                            chunk.timestamp,
-                                            buffered_duration_us as f64 / 1000.0,
-                                            chunk.data.len()
-                                        );
-                                    }
-
-                                    if !player_initialized {
-                                        let _ = player_tx.send(PlayerCommand::Init(
-                                            fmt.clone(),
-                                            Arc::clone(&clock_sync),
-                                        ));
-                                        player_initialized = true;
-                                    }
-
-                                    let buffer = AudioBuffer {
-                                        timestamp: chunk.timestamp,
-                                        samples,
-                                        format: fmt.clone(),
-                                    };
-                                    let _ = player_tx.send(PlayerCommand::Enqueue(buffer));
                                 }
-                                Err(e) => {
-                                    error!("Decode error: {}", e);
+                                Message::StreamEnd(stream_end) => {
+                                    debug!("Stream ended: {:?}", stream_end.roles);
+                                    let _ = player_tx.send(PlayerCommand::Clear);
+                                    buffered_duration_us = 0;
+                                    playback_started = false;
+                                    first_chunk_logged = false;
+                                    player_initialized = false;
+                                }
+                                Message::StreamClear(stream_clear) => {
+                                    debug!("Stream cleared: {:?}", stream_clear.roles);
+                                    let _ = player_tx.send(PlayerCommand::Clear);
+                                    buffered_duration_us = 0;
+                                    playback_started = false;
+                                    first_chunk_logged = false;
+                                    player_initialized = false;
+                                }
+                                Message::ServerCommand(cmd) => {
+                                    // debug!("Received server command: {}", );
+                                    // Set Volume
+                                    if !player_initialized {
+                                        log::warn!("Received server command before player initialized: {:?}", cmd);
+                                        continue;
+                                    }
+                                    match cmd.player {
+                                        None => {
+                                            log::warn!("Received server command without player field: {:?}", cmd);
+                                            continue;
+                                        }
+                                        Some(player) => {
+                                            match player.command {
+                                                PlayerCommandType::Volume => {
+                                                    match player.volume {
+                                                        None => {
+                                                            log::warn!("Received server command without volume field");
+                                                        }
+                                                        Some(vol) => {
+                                                            info!("Setting player volume to {}", vol);
+                                                            let _ = player_tx.send(PlayerCommand::SetVolume(vol));
+                                                        }
+                                                    }
+                                                }
+                                                PlayerCommandType::Mute => {
+                                                    match player.mute {
+                                                        None => {
+                                                            log::warn!("Received server command without muted field");
+                                                        }
+                                                        Some(mute) => {
+                                                            log::info!("Received mute command: {}", mute);
+                                                            let _ = player_tx.send(PlayerCommand::SetMute(mute));
+                                                            if let Err(e) = sender.send_message(Message::ClientState(
+                                                                ClientState {
+                                                                    state: None,
+                                                                    player: Some(PlayerState {
+                                                                        volume: None,
+                                                                        muted: Some(mute),
+                                                                        static_delay_ms: None,
+                                                                        supported_commands: None,
+                                                                        required_lead_time_ms: None,
+                                                                        min_buffer_ms: None
+                                                                    }),
+                                                                }
+                                                            )).await {
+                                                                warn!("Failed to send mute state to server: {}", e);
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                                _ => {
+                                                    debug!("Received unsupported server command: {:?}", player.command);
+                                                    continue;
+                                                }
+                                            }
+
+                                        }
+                                    }
+                                }
+                                _ => {
+                                    debug!("Received message: {:?}", msg);
                                 }
                             }
                         }
-                    }
-                    else => {
-                        debug!("Message and audio channels closed, exiting");
-                        // Both channels closed
-                        break;
+                        Some(chunk) = audio_rx.recv() => {
+                            // Log first chunk bytes for diagnostics
+                            if !first_chunk_logged {
+                                let preview_len = chunk.data.len().min(32);
+                                let hex_string = chunk.data[..preview_len]
+                                    .iter()
+                                    .map(|b| format!("{:02X}", b))
+                                    .collect::<Vec<_>>()
+                                    .join(" ");
+                                debug!("First {} bytes (hex): {}", preview_len, hex_string);
+                                first_chunk_logged = true;
+                            }
+
+                            if let Some(ref fmt) = audio_format {
+                                // Frame sanity check
+                                let bytes_per_sample = match fmt.bit_depth {
+                                    16 => 2,
+                                    24 => 3,
+                                    _ => {
+                                        error!("Unsupported bit depth: {}", fmt.bit_depth);
+                                        continue;
+                                    }
+                                } as usize;
+                                let frame_size = bytes_per_sample * fmt.channels as usize;
+
+                                if chunk.data.len() % frame_size != 0 {
+                                    error!(
+                                        "BAD FRAME: {} bytes not multiple of frame size {} ({}-bit, {}ch)",
+                                        chunk.data.len(), frame_size, fmt.bit_depth, fmt.channels
+                                    );
+                                    continue; // Don't decode garbage
+                                }
+
+                                // One-time endianness setup on first chunk
+                                // Per spec: macOS and most systems use Little-Endian PCM
+                                // Only use Big-Endian if explicitly signaled by server
+                                if endian_locked.is_none() {
+                                    // Default to Little-Endian (standard for macOS/Windows/Linux)
+                                    let endian = PcmEndian::Little;
+                                    endian_locked = Some(endian);
+                                    decoder = Some(PcmDecoder::with_endian(fmt.bit_depth, endian));
+                                    debug!("Using Little-Endian PCM (standard for modern systems)");
+                                }
+                            }
+
+                            if let (Some(ref dec), Some(ref fmt)) = (&decoder, &audio_format) {
+                                match dec.decode(&chunk.data) {
+                                    Ok(samples) => {
+                                        // Calculate chunk duration in microseconds
+                                        // samples.len() includes all channels
+                                        let frames = samples.len() / fmt.channels as usize;
+                                        let duration_micros = (frames as u64 * 1_000_000) / fmt.sample_rate as u64;
+                                        // Track buffered duration
+                                        buffered_duration_us += duration_micros;
+
+                                        // Check if we've buffered enough to start playback
+                                        if !playback_started && buffered_duration_us >= start_buffer_ms * 1000 {
+                                            playback_started = true;
+                                            debug!(
+                                                "Prebuffering complete ({:.1}ms buffered), starting playback!",
+                                                buffered_duration_us as f64 / 1000.0
+                                            );
+                                        }
+
+                                        // Track and log lead time
+                                        if log_lead {
+                                            trace!(
+                                                "Enqueued chunk ts={} buffered={:.1}ms len={} bytes",
+                                                chunk.timestamp,
+                                                buffered_duration_us as f64 / 1000.0,
+                                                chunk.data.len()
+                                            );
+                                        }
+
+                                        if !player_initialized {
+                                            let _ = player_tx.send(PlayerCommand::Init(
+                                                fmt.clone(),
+                                                Arc::clone(&clock_sync),
+                                            ));
+                                            player_initialized = true;
+                                        }
+
+                                        let buffer = AudioBuffer {
+                                            timestamp: chunk.timestamp,
+                                            samples,
+                                            format: fmt.clone(),
+                                        };
+                                        let _ = player_tx.send(PlayerCommand::Enqueue(buffer));
+                                    }
+                                    Err(e) => {
+                                        error!("Decode error: {}", e);
+                                    }
+                                }
+                            }
+                        }
+                        else => {
+                            debug!("Message and audio channels closed, exiting");
+                            // Both channels closed
+                            break;
+                        }
                     }
                 }
+
+                warn!(
+                    "Sendspin connection to {} closed; reconnecting in {:?}",
+                    server, backoff
+                );
+                let _ = player_tx.send(PlayerCommand::Clear);
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(max_backoff);
             }
-
-            // Shutdown the player thread
-            let _ = player_tx.send(PlayerCommand::Shutdown);
-
-            Ok(())
         })
     }
 }

--- a/components/sendspin/src/lib.rs
+++ b/components/sendspin/src/lib.rs
@@ -630,8 +630,9 @@ impl Module for UbiHomePlatform {
                             }
                         }
                         else => {
-                            debug!("Message and audio channels closed, exiting");
-                            // Both channels closed
+                            // Both channels closed: the connection dropped, so
+                            // leave the inner loop to reconnect.
+                            debug!("Message and audio channels closed; reconnecting");
                             break;
                         }
                     }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -9,7 +9,7 @@ use ubihome_core::internal::sensors::UbiComponent;
 use ubihome_core::{ChangedMessage, PublishedMessage};
 
 use futures_signals::signal::{Mutable, SignalExt};
-use log::{debug, trace, warn};
+use log::{debug, error, trace, warn};
 use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::path::Path;
@@ -167,6 +167,12 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
         let (internal_tx, modules_rx) = broadcast::channel::<PublishedMessage>(16);
         let (modules_tx, mut internal_rx) = broadcast::channel::<ChangedMessage>(16);
 
+        // Supervise every long-running task (sensor/binary-sensor signal handlers,
+        // the internal command router, and the platform modules) in one JoinSet so
+        // a panic in any of them brings the application down instead of being
+        // silently swallowed by a detached task.
+        let mut supervised_tasks: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
+
         // Double Option Workaround for https://github.com/Pauan/rust-signals/issues/75
         let mut signal_map_binary_sensor: HashMap<String, Mutable<Option<Option<bool>>>> = HashMap::new();
         let mut signal_map_sensor: HashMap<String, Mutable<Option<Option<f32>>>> = HashMap::new();
@@ -183,7 +189,7 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
                     let internal_tx_clone = internal_tx.clone();
 
                     let mutable_clone = mutable.clone();
-                    tokio::spawn(async move {
+                    supervised_tasks.spawn(async move {
                         // println!("Filters: {:?}", binary_sensor.filters);
 
                         let mut signal = mutable_clone.signal_cloned().boxed();
@@ -248,7 +254,7 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
                     let internal_tx_clone = internal_tx.clone();
 
                     let mutable_clone = mutable.clone();
-                    tokio::spawn(async move {
+                    supervised_tasks.spawn(async move {
                         // println!("Filters: {:?}", binary_sensor.filters);
 
                         let mut signal = mutable_clone.signal().boxed();
@@ -410,7 +416,7 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
         }
 
         let internal_tx_clone = internal_tx.clone();
-        tokio::spawn({
+        supervised_tasks.spawn({
             async move {
                 while let Ok(cmd) = internal_rx.recv().await {
                     debug!("Received command: {:?}", cmd);
@@ -464,7 +470,12 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
             }
         });
 
-        run_platforms(configured_platforms, modules_tx.clone(), modules_rx).await;
+        run_platforms(
+            &mut supervised_tasks,
+            configured_platforms,
+            modules_tx.clone(),
+            modules_rx,
+        );
 
         println!("Platforms: {:?}", initialized_platforms);
         internal_tx
@@ -507,6 +518,31 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
         #[cfg(not(unix))]
         let terminate = std::future::pending::<()>();
 
+        // Supervise every task in the set: a task returning normally (e.g. a module
+        // whose run() returned Ok(())) is an intentional exit and is ignored, but a
+        // task that panics (e.g. a module's run() returned Err via unwrap) is a real
+        // failure that must bring the whole application down gracefully.
+        let task_supervisor = async {
+            loop {
+                match supervised_tasks.join_next().await {
+                    // Task exited normally; keep supervising the rest.
+                    Some(Ok(())) => continue,
+                    // Task panicked. Sentry already captured it via the panic
+                    // integration; flush before we shut down so the event is sent.
+                    Some(Err(join_error)) => {
+                        error!("Task terminated abnormally: {}. Shutting down.", join_error);
+                        if let Some(client) = sentry::Hub::current().client() {
+                            client.flush(Some(Duration::from_secs(2)));
+                        }
+                        break;
+                    }
+                    // All tasks have exited normally; nothing left to supervise, so
+                    // keep waiting for a shutdown signal instead of exiting.
+                    None => std::future::pending::<()>().await,
+                }
+            }
+        };
+
         if let Some(some_shutdown_signal) = shutdown_signal {
             let shutdown_event = async {
                 loop {
@@ -524,11 +560,13 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
                 _ = ctrl_c => {},
                 _ = terminate => {},
                 _ = shutdown_event => {},
+                _ = task_supervisor => {},
             }
         } else {
             tokio::select! {
                 _ = ctrl_c => {},
                 _ = terminate => {},
+                _ = task_supervisor => {},
             }
         }
     });

--- a/src/components.rs
+++ b/src/components.rs
@@ -83,7 +83,8 @@ pub(crate) fn initialize_platforms(
     Ok(all_components)
 }
 
-pub(crate) async fn run_platforms(
+pub(crate) fn run_platforms(
+    tasks: &mut tokio::task::JoinSet<()>,
     modules: Vec<Box<dyn Module>>,
     sender: Sender<ChangedMessage>,
     receiver: Receiver<PublishedMessage>,
@@ -91,22 +92,91 @@ pub(crate) async fn run_platforms(
     for module in modules {
         let tx = sender.clone();
         let rx = receiver.resubscribe();
-        tokio::spawn({
-            async move {
-                module.run(tx, rx).await.unwrap();
-            }
+        tasks.spawn(async move {
+            // A module returning Ok(()) is a normal, intentional exit and stays
+            // silent. An Err is a real failure: unwrap panics, which is reported to
+            // Sentry by the panic integration. Tasks are collected in a JoinSet so
+            // the caller observes the panic (instead of it being swallowed by this
+            // task) and shuts the application down.
+            module.run(tx, rx).await.unwrap();
         });
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Platform;
+    use super::*;
+    use ubihome_core::ModuleRunFuture;
 
     #[test]
     fn test_reserved_platform_names_are_rejected() {
         let result = Platform::from_str("button");
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Reserved platform name"));
+    }
+
+    /// Minimal module whose `run` either exits normally or returns an error,
+    /// used to exercise how `run_platforms` supervises module tasks.
+    struct MockModule {
+        should_err: bool,
+    }
+
+    impl Module for MockModule {
+        fn new(_config_string: &str, _config_path: &str) -> Result<Self, String> {
+            Ok(MockModule { should_err: false })
+        }
+
+        fn components(&mut self) -> Vec<UbiComponent> {
+            Vec::new()
+        }
+
+        fn run(
+            &self,
+            _sender: Sender<ChangedMessage>,
+            _receiver: Receiver<PublishedMessage>,
+        ) -> ModuleRunFuture {
+            let should_err = self.should_err;
+            Box::pin(async move {
+                if should_err {
+                    Err("mock module failure".into())
+                } else {
+                    Ok(())
+                }
+            })
+        }
+    }
+
+    fn spawn_mock(should_err: bool) -> tokio::task::JoinSet<()> {
+        let (changed_tx, _changed_rx) = tokio::sync::broadcast::channel::<ChangedMessage>(16);
+        let (_published_tx, published_rx) = tokio::sync::broadcast::channel::<PublishedMessage>(16);
+        let mut tasks = tokio::task::JoinSet::new();
+        let modules: Vec<Box<dyn Module>> = vec![Box::new(MockModule { should_err })];
+        run_platforms(&mut tasks, modules, changed_tx, published_rx);
+        tasks
+    }
+
+    /// A module returning Ok(()) is an intentional exit: the task completes
+    /// normally so the supervisor leaves the application running.
+    #[tokio::test]
+    async fn run_platforms_normal_exit_completes_cleanly() {
+        let mut tasks = spawn_mock(false);
+        let joined = tasks.join_next().await.expect("one task was spawned");
+        assert!(
+            joined.is_ok(),
+            "a module returning Ok(()) must not panic its task"
+        );
+    }
+
+    /// A module returning Err is a real failure: unwrap panics, which the
+    /// supervisor observes (via a JoinError) to trigger application shutdown.
+    #[tokio::test]
+    async fn run_platforms_erroring_module_panics_task() {
+        let mut tasks = spawn_mock(true);
+        let joined = tasks.join_next().await.expect("one task was spawned");
+        let join_error = joined.expect_err("a module returning Err must panic its task");
+        assert!(
+            join_error.is_panic(),
+            "the failure must surface as a panic, not a cancellation"
+        );
     }
 }


### PR DESCRIPTION
Sendspin connections could drop silently (server restart, network blip, idle timeout), leaving the module dead with no logs and no reconnect until UbiHome restarted. Wrap connect + the message loop in a reconnect loop with exponential backoff (1s..30s), logging at warn/error, so the player recovers on its own. Also stop the mute-ack send from panicking on a dying connection.

Supervise every long-running task (sensor/binary-sensor signal handlers, the internal command router, and platform modules) in a single JoinSet. A task returning normally is an intentional exit and is ignored; a panic (e.g. a module's run() returning Err via unwrap) is observed by the supervisor, which flushes Sentry and shuts the application down gracefully — instead of the panic being swallowed by a detached task. This avoids a process-wide panic = "abort".