### PR TITLE
test(e2e): make Home Assistant e2e tests resilient and retry on flake

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,4 +1,5 @@
 import json
+import re
 import time
 import urllib.parse
 from collections.abc import AsyncGenerator, Generator
@@ -134,7 +135,10 @@ async def ha_page(
     await page.get_by_role("textbox", name="Username").fill(home_assistant_runtime.username)
     await page.get_by_role("textbox", name="Password").fill(home_assistant_runtime.password)
     await page.get_by_role("textbox", name="Password").press("Enter")
-    await page.wait_for_url("**/home/overview", timeout=60000)
+    # Home Assistant redirects to its default dashboard, whose view path varies
+    # (e.g. "/home/overview" or the by-index "/home/0") depending on how far
+    # dashboard generation has progressed, so match any dashboard landing URL.
+    await page.wait_for_url(re.compile(r"/(home|lovelace)(/|$)"), timeout=60000)
 
     try:
         yield page

--- a/tests/e2e/home_assistant_native_api_e2e_test.py
+++ b/tests/e2e/home_assistant_native_api_e2e_test.py
@@ -16,7 +16,11 @@ from playwright.async_api import (
 from mock_file import IOMockFactory
 from utils import SHELL_TYPE, UbiHome
 
-pytestmark = [pytest.mark.e2e, pytest.mark.timeout(30)]
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.timeout(30),
+    pytest.mark.flaky(reruns=1, reruns_delay=5),
+]
 
 
 def merge_dicts(base: dict[str, Any], overrides: Mapping[str, Any] | None) -> dict[str, Any]:

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-e2e = ["pytest-playwright-asyncio>=0.7.2"]
+e2e = ["pytest-playwright-asyncio>=0.7.2", "pytest-rerunfailures>=15.0"]
 dev = ["ruff>=0.4.0"]
 
 [tool.uv]

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -492,6 +492,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/60/a90ca1cc6cffcb97b4260ed0ad2b7934b999d7c48abe4ea0840344862a3b/pytest_rerunfailures-16.4.tar.gz", hash = "sha256:8222d17c37eb7b9e4d6fc96a3c724ff4e1a5c97a5cc7cbb2c19e9282cfd21a11", size = 36635, upload-time = "2026-07-01T06:30:56.813Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/93/3cdcc4033444e822e01b573414b03fd37fd5533070c750477b8f5fa5224b/pytest_rerunfailures-16.4-py3-none-any.whl", hash = "sha256:f69b5beb39622c90d1e44bd945d826eff6db545dcf0b68f52b7e4ad15eaf6d6c", size = 16955, upload-time = "2026-07-01T06:30:55.333Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -625,6 +638,7 @@ dev = [
 ]
 e2e = [
     { name = "pytest-playwright-asyncio" },
+    { name = "pytest-rerunfailures" },
 ]
 
 [package.metadata]
@@ -641,7 +655,10 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [{ name = "ruff", specifier = ">=0.4.0" }]
-e2e = [{ name = "pytest-playwright-asyncio", specifier = ">=0.7.2" }]
+e2e = [
+    { name = "pytest-playwright-asyncio", specifier = ">=0.7.2" },
+    { name = "pytest-rerunfailures", specifier = ">=15.0" },
+]
 
 [[package]]
 name = "text-unidecode"


### PR DESCRIPTION
The ha_page fixture waited for the exact URL "**/home/overview" after login, but Home Assistant sometimes redirects to the by-index view "**/home/0" depending on how far dashboard generation has progressed, causing a TimeoutError at fixture setup that blocked the pipeline.

- Match any dashboard landing URL via regex instead of a fixed glob.
- Add pytest-rerunfailures and mark the e2e module flaky (reruns=1) so transient container/login failures self-heal instead of failing CI.