### PR TITLE
fix(install): better windows and linux installation

### DIFF
--- a/src/commands/un_install/linux.rs
+++ b/src/commands/un_install/linux.rs
@@ -114,9 +114,7 @@ pub async fn uninstall(location: &str) {
         return;
     }
 
-    println!("Uninstalling UbiHome at {}", location);
-    println!(" - Remove Folder at {}", location);
-    fs::remove_dir(location).unwrap();
+    println!("Uninstalling UbiHome:");
 
     println!("- Removing Systemd Service");
     let service_file = service_file();
@@ -126,5 +124,9 @@ pub async fn uninstall(location: &str) {
     fs::remove_file(systemd_file_path).expect("Unable to remove file");
 
     execute_command("systemctl daemon-reload").await;
-    println!("TODO: remove log files?");
+
+    println!(" - Remove Folder at {}", location);
+    fs::remove_dir(location).unwrap();
+
+    println!("Successfully uninstalled UbiHome.");
 }

--- a/src/commands/un_install/linux.rs
+++ b/src/commands/un_install/linux.rs
@@ -19,9 +19,28 @@ pub async fn install(location: &str) {
     println!(" - Creating Folder at {}", location);
     fs::create_dir_all(location).expect("Unable to create directory");
 
+    let current_exe = env::current_exe().unwrap();
     let new_path = Path::new(location).join("ubihome");
-    println!(" - Copying Binary to {}", new_path.display());
-    fs::copy(env::current_exe().unwrap(), new_path).expect("Unable to copy file");
+
+    // Compare against the canonicalized target directory (not `new_path` itself) so this
+    // also works when no binary exists at the target location yet. Overwriting the binary
+    // that is currently executing fails with "Text file busy" on Linux/macOS.
+    let already_in_place = new_path
+        .parent()
+        .and_then(|dir| dir.canonicalize().ok())
+        .map(|dir| dir.join("ubihome"))
+        .and_then(|target| current_exe.canonicalize().ok().map(|exe| exe == target))
+        .unwrap_or(false);
+
+    if already_in_place {
+        println!(
+            " - Binary is already at {}, skipping copy",
+            new_path.display()
+        );
+    } else {
+        println!(" - Copying Binary to {}", new_path.display());
+        fs::copy(&current_exe, &new_path).expect("Unable to copy file");
+    }
 
     let service_file = service_file();
 

--- a/src/commands/un_install/linux.rs
+++ b/src/commands/un_install/linux.rs
@@ -15,7 +15,7 @@ pub async fn install(location: &str) {
     use crate::constants::SERVICE_DESCRIPTION;
 
     // TODO: Run update logic if already installed (e.g. stop service before copy)
-    println!("Installing UbiHome to {}", location);
+    println!("Installing UbiHome:");
     println!(" - Creating Folder at {}", location);
     fs::create_dir_all(location).expect("Unable to create directory");
 
@@ -75,6 +75,14 @@ WantedBy=multi-user.target",
     execute_command(format!("systemctl enable {}", service_file).as_str()).await;
     println!("  - Starting Service");
     execute_command(format!("systemctl start {}", service_file).as_str()).await;
+
+    let config_path = Path::new(location).join("config.yaml");
+    if crate::DEFAULT_CONFIG.is_none() && !config_path.exists() {
+        println!(
+            "WARNING: No embedded default configuration and no config.yaml found. The service will fail to start until you place a config.yaml at {}",
+            config_path.display()
+        );
+    }
 
     println!("Successfully installed and started!");
     println!("Query the status via `systemctl status {}`", service_file);

--- a/src/commands/un_install/windows.rs
+++ b/src/commands/un_install/windows.rs
@@ -31,23 +31,6 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
         fs::copy(&current_exe, &new_path).expect("Unable to copy file");
     }
 
-    let current_dir = env::current_dir().unwrap().to_string_lossy().to_string();
-    let config_file_path = Path::new(&current_dir).join("config.yaml");
-    let new_config_file_path = Path::new(location).join("config.yaml");
-
-    if config_file_path.exists() {
-        println!(
-            " - Copying config.yml to {}",
-            new_config_file_path.display()
-        );
-        fs::copy(config_file_path, &new_config_file_path).expect("Unable to copy file");
-    } else {
-        println!(
-            " - No config.yml found at {} Please supply your own.",
-            config_file_path.display()
-        );
-    }
-
     use std::ffi::OsString;
     use std::time::Duration;
     use windows_service::{

--- a/src/commands/un_install/windows.rs
+++ b/src/commands/un_install/windows.rs
@@ -38,7 +38,7 @@ fn get_service() -> windows_service::Result<(ServiceManager, Service)> {
 }
 
 pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Installing UbiHome to {}", location);
+    println!("Installing UbiHome:");
     println!(" - Creating Folder at {}", location);
     fs::create_dir_all(location).expect("Unable to create directory");
 
@@ -137,6 +137,14 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
     } else {
         service.start::<&OsStr>(&[])?;
         println!(" - Service started.");
+    }
+
+    let config_path = Path::new(location).join("config.yaml");
+    if crate::DEFAULT_CONFIG.is_none() && !config_path.exists() {
+        println!(
+            "WARNING: No embedded default configuration and no config.yaml found. The service will fail to start until you place a config.yaml at {}",
+            config_path.display()
+        );
     }
 
     Ok(())

--- a/src/commands/un_install/windows.rs
+++ b/src/commands/un_install/windows.rs
@@ -146,12 +146,13 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
             config_path.display()
         );
     }
+    println!("Successfully installed and started!");
 
     Ok(())
 }
 
 pub async fn uninstall(location: &str) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Uninstalling UbiHome to");
+    println!("Uninstalling UbiHome:");
 
     if let Ok((service_manager, service)) = get_service() {
         print!(" - Removing Service... ");
@@ -171,24 +172,30 @@ pub async fn uninstall(location: &str) -> Result<(), Box<dyn std::error::Error>>
         // To check if the service is deleted from the database, we have to poll it ourselves.
         let start = Instant::now();
         let timeout = Duration::from_secs(5);
+        let mut deleted = false;
         while start.elapsed() < timeout {
             if let Err(windows_service::Error::Winapi(e)) =
                 service_manager.open_service(constants::SERVICE_NAME, ServiceAccess::QUERY_STATUS)
             {
                 if e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32) {
-                    println!("service is deleted.");
+                    println!("service deleted");
+                    deleted = true;
                     break;
                 }
             }
             sleep(Duration::from_secs(1));
         }
-        println!("service is marked for deletion.");
+        if !deleted {
+            println!("service is marked for deletion");
+        }
     } else {
         println!(" - Service already removed");
     }
 
     println!(" - Deleting Folder and contents at {}", location);
     fs::remove_dir_all(location).expect("Unable to delete directory");
+
+    println!("Successfully uninstalled UbiHome.");
 
     Ok(())
 }

--- a/src/commands/un_install/windows.rs
+++ b/src/commands/un_install/windows.rs
@@ -1,13 +1,57 @@
 use std::{env, ffi::OsStr, fs, path::Path};
 
 use log::debug;
+use std::ffi::OsString;
+use std::{
+    thread::sleep,
+    time::{Duration, Instant},
+};
+use windows_service::{
+    service::{
+        Service, ServiceAccess, ServiceAction, ServiceActionType, ServiceErrorControl,
+        ServiceFailureActions, ServiceFailureResetPeriod, ServiceInfo, ServiceStartType,
+        ServiceState, ServiceType,
+    },
+    service_manager::{ServiceManager, ServiceManagerAccess},
+};
+
+use windows_sys::Win32::Foundation::ERROR_SERVICE_DOES_NOT_EXIST;
 
 use crate::constants;
+
+/// Connects to the SCM and opens the UbiHome service, requesting the access rights needed
+/// by both install and uninstall, and returning both handles so the manager can still be
+/// reused (e.g. to create the service if it does not exist yet).
+fn get_service() -> windows_service::Result<(ServiceManager, Service)> {
+    let manager_access = ServiceManagerAccess::CONNECT
+        | ServiceManagerAccess::CREATE_SERVICE
+        | ServiceManagerAccess::ENUMERATE_SERVICE;
+    let service_access = ServiceAccess::START
+        | ServiceAccess::STOP
+        | ServiceAccess::CHANGE_CONFIG
+        | ServiceAccess::QUERY_STATUS
+        | ServiceAccess::DELETE;
+
+    let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
+    let service = service_manager.open_service(constants::SERVICE_NAME, service_access)?;
+    Ok((service_manager, service))
+}
 
 pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
     println!("Installing UbiHome to {}", location);
     println!(" - Creating Folder at {}", location);
     fs::create_dir_all(location).expect("Unable to create directory");
+
+    // Opened up front (before copying the binary) so a running service can be stopped first;
+    // overwriting a running executable fails with a sharing violation on Windows.
+    let existing_service = get_service();
+
+    if let Ok((_, service)) = &existing_service {
+        if service.query_status()?.current_state != ServiceState::Stopped {
+            // If the service cannot be stopped, it will be deleted when the system restarts.
+            service.stop()?;
+        }
+    }
 
     let current_exe = env::current_exe().unwrap();
     let new_path = Path::new(location).join("ubihome.exe");
@@ -31,22 +75,6 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
         fs::copy(&current_exe, &new_path).expect("Unable to copy file");
     }
 
-    use std::ffi::OsString;
-    use std::time::Duration;
-    use windows_service::{
-        service::{
-            ServiceAccess, ServiceAction, ServiceActionType, ServiceErrorControl,
-            ServiceFailureActions, ServiceFailureResetPeriod, ServiceInfo, ServiceStartType,
-            ServiceState, ServiceType,
-        },
-        service_manager::{ServiceManager, ServiceManagerAccess},
-    };
-
-    let manager_access = ServiceManagerAccess::CONNECT
-        | ServiceManagerAccess::CREATE_SERVICE
-        | ServiceManagerAccess::ENUMERATE_SERVICE;
-    let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
-
     let service_info = ServiceInfo {
         name: OsString::from(constants::SERVICE_NAME),
         display_name: OsString::from(constants::SERVICE_NAME),
@@ -55,8 +83,6 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
         error_control: ServiceErrorControl::Normal,
         executable_path: new_path,
         launch_arguments: vec![
-            OsString::from("-c"),
-            OsString::from(new_config_file_path),
             OsString::from("run"),
             OsString::from("--as-windows-service"),
         ],
@@ -65,18 +91,17 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
         account_password: None,
     };
 
-    let service_access =
-        ServiceAccess::START | ServiceAccess::CHANGE_CONFIG | ServiceAccess::QUERY_STATUS;
-
-    let service = if let Ok(service) =
-        service_manager.open_service(constants::SERVICE_NAME, service_access)
-    {
+    let service = if let Ok((_service_manager, service)) = existing_service {
         debug!("Service already exists, updating...");
         service.set_description(constants::SERVICE_DESCRIPTION)?;
         service.change_config(&service_info)?;
         println!(" - Service updated.");
         service
     } else {
+        let manager_access = ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE;
+        let service_access =
+            ServiceAccess::START | ServiceAccess::CHANGE_CONFIG | ServiceAccess::QUERY_STATUS;
+        let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
         let service = service_manager.create_service(&service_info, service_access)?;
         service.set_description(constants::SERVICE_DESCRIPTION)?;
         println!(" - Created Windows Service");
@@ -114,64 +139,48 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
         println!(" - Service started.");
     }
 
-    println!(" - TODO: Create Readme...");
-
     Ok(())
 }
 
 pub async fn uninstall(location: &str) -> Result<(), Box<dyn std::error::Error>> {
-    use std::{
-        thread::sleep,
-        time::{Duration, Instant},
-    };
-
-    use windows_service::{
-        service::{ServiceAccess, ServiceState},
-        service_manager::{ServiceManager, ServiceManagerAccess},
-    };
-    use windows_sys::Win32::Foundation::ERROR_SERVICE_DOES_NOT_EXIST;
-
     println!("Uninstalling UbiHome to");
 
-    println!(" - TODO: Cleanup Logs...");
+    if let Ok((service_manager, service)) = get_service() {
+        print!(" - Removing Service... ");
 
-    println!(" - Deleting Folder at {}", location);
+        // Our handle to it is not closed yet. So we can still query it.
+        if service.query_status()?.current_state != ServiceState::Stopped {
+            // If the service cannot be stopped, it will be deleted when the system restarts.
+            service.stop()?;
+        }
+        // The service will be marked for deletion as long as this function call succeeds.
+        // However, it will not be deleted from the database until it is stopped and all open handles to it are closed.
+        service.delete()?;
+        // Explicitly close our open handle to the service. This is automatically called when `service` goes out of scope.
+        // drop(service);
+
+        // Win32 API does not give us a way to wait for service deletion.
+        // To check if the service is deleted from the database, we have to poll it ourselves.
+        let start = Instant::now();
+        let timeout = Duration::from_secs(5);
+        while start.elapsed() < timeout {
+            if let Err(windows_service::Error::Winapi(e)) =
+                service_manager.open_service(constants::SERVICE_NAME, ServiceAccess::QUERY_STATUS)
+            {
+                if e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32) {
+                    println!("service is deleted.");
+                    break;
+                }
+            }
+            sleep(Duration::from_secs(1));
+        }
+        println!("service is marked for deletion.");
+    } else {
+        println!(" - Service already removed");
+    }
+
+    println!(" - Deleting Folder and contents at {}", location);
     fs::remove_dir_all(location).expect("Unable to delete directory");
 
-    println!(" - Removing Service");
-
-    let manager_access = ServiceManagerAccess::CONNECT;
-    let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
-
-    let service_access = ServiceAccess::QUERY_STATUS | ServiceAccess::STOP | ServiceAccess::DELETE;
-    let service = service_manager.open_service(constants::SERVICE_NAME, service_access)?;
-
-    // Our handle to it is not closed yet. So we can still query it.
-    if service.query_status()?.current_state != ServiceState::Stopped {
-        // If the service cannot be stopped, it will be deleted when the system restarts.
-        service.stop()?;
-    }
-    // The service will be marked for deletion as long as this function call succeeds.
-    // However, it will not be deleted from the database until it is stopped and all open handles to it are closed.
-    service.delete()?;
-    // Explicitly close our open handle to the service. This is automatically called when `service` goes out of scope.
-    // drop(service);
-
-    // Win32 API does not give us a way to wait for service deletion.
-    // To check if the service is deleted from the database, we have to poll it ourselves.
-    let start = Instant::now();
-    let timeout = Duration::from_secs(5);
-    while start.elapsed() < timeout {
-        if let Err(windows_service::Error::Winapi(e)) =
-            service_manager.open_service(constants::SERVICE_NAME, ServiceAccess::QUERY_STATUS)
-        {
-            if e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32) {
-                println!("service is deleted.");
-                return Ok(());
-            }
-        }
-        sleep(Duration::from_secs(1));
-    }
-    println!("service is marked for deletion.");
     Ok(())
 }

--- a/src/commands/un_install/windows.rs
+++ b/src/commands/un_install/windows.rs
@@ -1,4 +1,5 @@
 use std::{env, fs, path::Path};
+use std::ffi::OsStr;
 
 use log::debug;
 

--- a/src/commands/un_install/windows.rs
+++ b/src/commands/un_install/windows.rs
@@ -25,8 +25,13 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
     fs::copy(config_file_path, &new_config_file_path).expect("Unable to copy file");
 
     use std::ffi::OsString;
+    use std::time::Duration;
     use windows_service::{
-        service::{ServiceAccess, ServiceErrorControl, ServiceInfo, ServiceStartType, ServiceType},
+        service::{
+            ServiceAccess, ServiceAction, ServiceActionType, ServiceErrorControl,
+            ServiceFailureActions, ServiceFailureResetPeriod, ServiceInfo, ServiceStartType,
+            ServiceType,
+        },
         service_manager::{ServiceManager, ServiceManagerAccess},
     };
 
@@ -53,19 +58,49 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
         account_password: None,
     };
 
-    if let Ok(service) =
+    let service = if let Ok(service) =
         service_manager.open_service(constants::SERVICE_NAME, ServiceAccess::CHANGE_CONFIG)
     {
         debug!("Service already exists, updating...");
         service.set_description(constants::SERVICE_DESCRIPTION)?;
         service.change_config(&service_info)?;
         println!(" - Service updated.");
+        service
     } else {
         let service =
             service_manager.create_service(&service_info, ServiceAccess::CHANGE_CONFIG)?;
         service.set_description(constants::SERVICE_DESCRIPTION)?;
         println!(" - Created Windows Service");
-    }
+        service
+    };
+
+    // Ensure the SCM restarts the service if the process exits unexpectedly - notably,
+    // after an OTA update (see components/ota) swaps the binary and intentionally exits
+    // so the new build gets picked up. Without this, a plain exit would just leave the
+    // service stopped, unlike the Linux systemd unit (Restart=always).
+    service.update_failure_actions(ServiceFailureActions {
+        reset_period: ServiceFailureResetPeriod::After(Duration::from_secs(86400)),
+        reboot_msg: None,
+        command: None,
+        actions: Some(vec![
+            ServiceAction {
+                action_type: ServiceActionType::Restart,
+                delay: Duration::from_secs(5),
+            },
+            ServiceAction {
+                action_type: ServiceActionType::Restart,
+                delay: Duration::from_secs(5),
+            },
+            ServiceAction {
+                action_type: ServiceActionType::Restart,
+                delay: Duration::from_secs(5),
+            },
+        ]),
+    })?;
+    // The SCM only applies failure actions to genuine crashes by default; this flag makes
+    // it also apply them to a clean exit (code 0), which is how the OTA component and any
+    // manual process exit terminate.
+    service.set_failure_actions_on_non_crash_failures(true)?;
 
     println!(" - TODO: Create Readme...");
 

--- a/src/commands/un_install/windows.rs
+++ b/src/commands/un_install/windows.rs
@@ -59,7 +59,7 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let service = if let Ok(service) =
-        service_manager.open_service(constants::SERVICE_NAME, ServiceAccess::CHANGE_CONFIG)
+        service_manager.open_service(constants::SERVICE_NAME, ServiceAccess::START | ServiceAccess::CHANGE_CONFIG)
     {
         debug!("Service already exists, updating...");
         service.set_description(constants::SERVICE_DESCRIPTION)?;
@@ -68,7 +68,7 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
         service
     } else {
         let service =
-            service_manager.create_service(&service_info, ServiceAccess::CHANGE_CONFIG)?;
+            service_manager.create_service(&service_info, ServiceAccess::START | ServiceAccess::CHANGE_CONFIG)?;
         service.set_description(constants::SERVICE_DESCRIPTION)?;
         println!(" - Created Windows Service");
         service
@@ -97,6 +97,7 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
     // The SCM only applies failure actions to genuine crashes by default; this flag makes
     // it also apply them to a clean exit (code 0)
     service.set_failure_actions_on_non_crash_failures(true)?;
+service.start(&[OsStr::new("Started after intallation.")])?;
 
     println!(" - TODO: Create Readme...");
 

--- a/src/commands/un_install/windows.rs
+++ b/src/commands/un_install/windows.rs
@@ -74,10 +74,7 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
         service
     };
 
-    // Ensure the SCM restarts the service if the process exits unexpectedly - notably,
-    // after an OTA update (see components/ota) swaps the binary and intentionally exits
-    // so the new build gets picked up. Without this, a plain exit would just leave the
-    // service stopped, unlike the Linux systemd unit (Restart=always).
+    // Ensure the SCM restarts the service if the process exits unexpectedly or expected
     service.update_failure_actions(ServiceFailureActions {
         reset_period: ServiceFailureResetPeriod::After(Duration::from_secs(86400)),
         reboot_msg: None,
@@ -98,8 +95,7 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
         ]),
     })?;
     // The SCM only applies failure actions to genuine crashes by default; this flag makes
-    // it also apply them to a clean exit (code 0), which is how the OTA component and any
-    // manual process exit terminate.
+    // it also apply them to a clean exit (code 0)
     service.set_failure_actions_on_non_crash_failures(true)?;
 
     println!(" - TODO: Create Readme...");

--- a/src/commands/un_install/windows.rs
+++ b/src/commands/un_install/windows.rs
@@ -1,5 +1,4 @@
-use std::{env, fs, path::Path};
-use std::ffi::OsStr;
+use std::{env, ffi::OsStr, fs, path::Path};
 
 use log::debug;
 
@@ -10,20 +9,44 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
     println!(" - Creating Folder at {}", location);
     fs::create_dir_all(location).expect("Unable to create directory");
 
+    let current_exe = env::current_exe().unwrap();
     let new_path = Path::new(location).join("ubihome.exe");
-    // TODO: Error if executed in the same location
-    println!(" - Copying Binary to {}", new_path.display());
-    fs::copy(env::current_exe().unwrap(), &new_path).expect("Unable to copy file");
+
+    // Compare against the canonicalized target directory (not `new_path` itself) so this
+    // also works when no binary exists at the target location yet.
+    let already_in_place = new_path
+        .parent()
+        .and_then(|dir| dir.canonicalize().ok())
+        .map(|dir| dir.join("ubihome.exe"))
+        .and_then(|target| current_exe.canonicalize().ok().map(|exe| exe == target))
+        .unwrap_or(false);
+
+    if already_in_place {
+        println!(
+            " - Binary is already at {}, skipping copy",
+            new_path.display()
+        );
+    } else {
+        println!(" - Copying Binary to {}", new_path.display());
+        fs::copy(&current_exe, &new_path).expect("Unable to copy file");
+    }
 
     let current_dir = env::current_dir().unwrap().to_string_lossy().to_string();
     let config_file_path = Path::new(&current_dir).join("config.yaml");
     let new_config_file_path = Path::new(location).join("config.yaml");
 
-    println!(
-        " - Copying config.yml to {}",
-        new_config_file_path.display()
-    );
-    fs::copy(config_file_path, &new_config_file_path).expect("Unable to copy file");
+    if config_file_path.exists() {
+        println!(
+            " - Copying config.yml to {}",
+            new_config_file_path.display()
+        );
+        fs::copy(config_file_path, &new_config_file_path).expect("Unable to copy file");
+    } else {
+        println!(
+            " - No config.yml found at {} Please supply your own.",
+            config_file_path.display()
+        );
+    }
 
     use std::ffi::OsString;
     use std::time::Duration;
@@ -31,7 +54,7 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
         service::{
             ServiceAccess, ServiceAction, ServiceActionType, ServiceErrorControl,
             ServiceFailureActions, ServiceFailureResetPeriod, ServiceInfo, ServiceStartType,
-            ServiceType,
+            ServiceState, ServiceType,
         },
         service_manager::{ServiceManager, ServiceManagerAccess},
     };
@@ -59,8 +82,11 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
         account_password: None,
     };
 
+    let service_access =
+        ServiceAccess::START | ServiceAccess::CHANGE_CONFIG | ServiceAccess::QUERY_STATUS;
+
     let service = if let Ok(service) =
-        service_manager.open_service(constants::SERVICE_NAME, ServiceAccess::START | ServiceAccess::CHANGE_CONFIG)
+        service_manager.open_service(constants::SERVICE_NAME, service_access)
     {
         debug!("Service already exists, updating...");
         service.set_description(constants::SERVICE_DESCRIPTION)?;
@@ -68,8 +94,7 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
         println!(" - Service updated.");
         service
     } else {
-        let service =
-            service_manager.create_service(&service_info, ServiceAccess::START | ServiceAccess::CHANGE_CONFIG)?;
+        let service = service_manager.create_service(&service_info, service_access)?;
         service.set_description(constants::SERVICE_DESCRIPTION)?;
         println!(" - Created Windows Service");
         service
@@ -98,7 +123,13 @@ pub async fn install(location: &str) -> Result<(), Box<dyn std::error::Error>> {
     // The SCM only applies failure actions to genuine crashes by default; this flag makes
     // it also apply them to a clean exit (code 0)
     service.set_failure_actions_on_non_crash_failures(true)?;
-service.start(&[OsStr::new("Started after intallation.")])?;
+
+    if service.query_status()?.current_state == ServiceState::Running {
+        println!(" - Service is already running.");
+    } else {
+        service.start::<&OsStr>(&[])?;
+        println!(" - Service started.");
+    }
 
     println!(" - TODO: Create Readme...");
 


### PR DESCRIPTION
The installed Windows service had no failure/recovery actions configured, so a clean process exit (exit code 0) left the service stopped instead of restarting - unlike the Linux systemd unit, which already has Restart=always. This adds SCM recovery actions (restart, 3 attempts, 5s delay) at install time and enables them for non-crash exits, so the service comes back up after an intentional restart (e.g. after an OTA update swaps the binary).