### PR TITLE
feat(ota): add device-side OTA update receiver component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5633,7 +5633,6 @@ dependencies = [
  "reqwest 0.12.28",
  "rumqttc",
  "rust-embed",
- "self-replace",
  "sentry",
  "serde",
  "serde-saphyr 0.0.23",
@@ -5648,6 +5647,7 @@ dependencies = [
  "ubihome-mdns",
  "ubihome-mqtt",
  "ubihome-online",
+ "ubihome-ota",
  "ubihome-power_utils",
  "ubihome-sendspin",
  "ubihome-shell",
@@ -5713,6 +5713,7 @@ dependencies = [
  "getifs",
  "log",
  "regex",
+ "self-replace",
  "serde",
  "serde-saphyr 0.0.26",
  "serde-value",
@@ -5806,6 +5807,27 @@ dependencies = [
  "serde",
  "serde_yaml",
  "tokio",
+ "ubihome-core",
+]
+
+[[package]]
+name = "ubihome-ota"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "current_platform",
+ "duration-str",
+ "garde",
+ "hex",
+ "log",
+ "rand 0.8.6",
+ "serde",
+ "serde-saphyr 0.0.26",
+ "serde_json",
+ "sha2",
+ "subtle",
+ "tokio",
+ "tower-http",
  "ubihome-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,13 @@ serde = { version = "1.0", features = ["derive"] }
 ubihome-api = { path = "components/api" }
 ubihome-bluetooth_proxy = { path = "components/bluetooth_proxy" }
 ubihome-bme280 = { path = "components/bme280" }
-ubihome-core = { path = "components/core" }
+ubihome-core = { path = "components/core", features = ["self_update"] }
 ubihome-gpio = { path = "components/gpio" }
 ubihome-illuminance = { path = "components/illuminance" }
 ubihome-online = { path = "components/online" }
 ubihome-mdns = { path = "components/mdns" }
 ubihome-mqtt = { path = "components/mqtt" }
+ubihome-ota = { path = "components/ota" }
 ubihome-power_utils = { path = "components/power_utils" }
 ubihome-sendspin = { path = "components/sendspin" }
 ubihome-shell = { path = "components/shell" }
@@ -33,7 +34,6 @@ reqwest = { version = "0.12.15", features = [
     "rustls-tls",
     "stream",
 ], default-features = false }
-self-replace = "1.5.0"
 current_platform = "0.2.0"
 indicatif = "0.17.8"
 futures-util = "0.3.31"
@@ -78,6 +78,7 @@ members = [
     "components/online",
     "components/mdns",
     "components/mqtt",
+    "components/ota",
     "components/power_utils",
     "components/sendspin",
     "components/shell",

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -8,6 +8,7 @@ description = "Core package"
 [features]
 ip = ["dep:getifs"]
 validation = ["serde-saphyr"]
+self_update = ["dep:self-replace"]
 
 [dependencies]
 log = "0.4"
@@ -23,3 +24,4 @@ serde-saphyr = { version = "0.0.26", features = [
   "garde",
   "miette",
 ], optional = true }
+self-replace = { version = "1.5.0", optional = true }

--- a/components/core/src/features/mod.rs
+++ b/components/core/src/features/mod.rs
@@ -1,2 +1,4 @@
 #[cfg(feature = "ip")]
 pub mod ip;
+#[cfg(feature = "self_update")]
+pub mod self_update;

--- a/components/core/src/features/self_update.rs
+++ b/components/core/src/features/self_update.rs
@@ -1,0 +1,21 @@
+use std::env;
+
+/// Writes `bytes` to a sibling temp file next to the running executable and
+/// atomically swaps it in via `self_replace`. Callers are responsible for
+/// verifying the bytes (checksum/signature) before calling this - once called,
+/// the running binary is replaced on disk.
+pub fn apply_new_binary(bytes: &[u8]) -> Result<(), String> {
+    let exe_path = env::current_exe().map_err(|e| e.to_string())?;
+
+    let mut new_exe_path = exe_path.clone();
+    new_exe_path.set_file_name(format!(
+        "new_{}",
+        exe_path.file_name().unwrap_or_default().to_string_lossy()
+    ));
+
+    std::fs::write(&new_exe_path, bytes).map_err(|e| e.to_string())?;
+    self_replace::self_replace(&new_exe_path).map_err(|e| e.to_string())?;
+    std::fs::remove_file(&new_exe_path).ok();
+
+    Ok(())
+}

--- a/components/ota/Cargo.toml
+++ b/components/ota/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ubihome-ota"
+version = "0.1.0"
+authors = ["Daniel Habenicht <daniel-habenicht@outlook.de>"]
+edition = "2021"
+
+[dependencies]
+log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+duration-str = "0.16.1"
+axum = { version = "0.8.4", features = ["tokio"] }
+tower-http = { version = "0.6.2", features = ["timeout", "trace"] }
+serde-saphyr = { version = "0.0.26", features = ["garde", "miette"] }
+garde = { version = "0.22.1", features = ["serde"] }
+tokio = { version = "1", features = ["full"] }
+ubihome-core = { path = "../core", features = ["validation", "self_update"] }
+sha2 = "0.10.9"
+subtle = "2.6.1"
+hex = "0.4.3"
+rand = "0.8"
+current_platform = "0.2.0"

--- a/components/ota/src/lib.rs
+++ b/components/ota/src/lib.rs
@@ -1,0 +1,409 @@
+use std::{
+    collections::HashMap,
+    future::Future,
+    net::{IpAddr, SocketAddr},
+    pin::Pin,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use axum::{
+    body::Bytes,
+    extract::{ConnectInfo, DefaultBodyLimit, Request, State},
+    http::{HeaderMap, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use log::{debug, error, info, warn};
+use rand::RngCore;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+use tokio::{
+    net::TcpSocket,
+    sync::{
+        broadcast::{Receiver, Sender},
+        Mutex,
+    },
+};
+use ubihome_core::{
+    config_template, internal::sensors::UbiComponent, ChangedMessage, Module, NoConfig,
+    PublishedMessage,
+};
+
+/// How long an issued challenge nonce stays valid, and thus replayable.
+const NONCE_TTL: Duration = Duration::from_secs(30);
+/// A whole executable is always well over this; guards against obviously bogus uploads
+/// before spending time on the SHA-256 pass.
+const MIN_BINARY_SIZE: usize = 1_000_000;
+const MAX_FAILED_ATTEMPTS: u32 = 5;
+const LOCKOUT_DURATION: Duration = Duration::from_secs(60);
+
+const fn default_port() -> u16 {
+    3232
+}
+
+const fn default_max_binary_size() -> u64 {
+    200_000_000
+}
+
+#[derive(Clone, Deserialize, Debug, Validate)]
+#[serde(deny_unknown_fields)]
+pub struct OtaConfig {
+    #[serde(default = "default_port")]
+    #[garde(range(min = 1, max = 65535))]
+    pub port: u16,
+
+    #[garde(ascii, length(min = 32, max = 256))]
+    pub password: String,
+
+    #[serde(default = "default_max_binary_size")]
+    #[garde(range(min = 1_000_000, max = 500_000_000))]
+    pub max_binary_size: u64,
+}
+
+config_template!(
+    ota, OtaConfig, NoConfig, NoConfig, NoConfig, NoConfig, NoConfig, NoConfig, NoConfig
+);
+
+struct FailureRecord {
+    count: u32,
+    window_start: Instant,
+    locked_until: Option<Instant>,
+}
+
+struct AppState {
+    config: CoreConfig,
+    // Single-use, short-lived challenges: value is when the nonce was issued.
+    nonces: Mutex<HashMap<String, Instant>>,
+    failed_attempts: Mutex<HashMap<IpAddr, FailureRecord>>,
+}
+
+#[derive(Serialize)]
+struct ChallengeResponse {
+    nonce: String,
+}
+
+fn generate_nonce() -> String {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+async fn handle_challenge(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let nonce = generate_nonce();
+    let now = Instant::now();
+
+    let mut nonces = state.nonces.lock().await;
+    nonces.retain(|_, issued_at| now.duration_since(*issued_at) < NONCE_TTL);
+    nonces.insert(nonce.clone(), now);
+
+    Json(ChallengeResponse { nonce })
+}
+
+async fn is_locked_out(state: &AppState, ip: IpAddr) -> bool {
+    let attempts = state.failed_attempts.lock().await;
+    match attempts.get(&ip).and_then(|record| record.locked_until) {
+        Some(locked_until) => Instant::now() < locked_until,
+        None => false,
+    }
+}
+
+async fn record_auth_failure(state: &AppState, ip: IpAddr) {
+    let mut attempts = state.failed_attempts.lock().await;
+    let now = Instant::now();
+    let record = attempts.entry(ip).or_insert(FailureRecord {
+        count: 0,
+        window_start: now,
+        locked_until: None,
+    });
+
+    if now.duration_since(record.window_start) > LOCKOUT_DURATION {
+        record.count = 0;
+        record.window_start = now;
+        record.locked_until = None;
+    }
+
+    record.count += 1;
+    if record.count >= MAX_FAILED_ATTEMPTS {
+        record.locked_until = Some(now + LOCKOUT_DURATION);
+    }
+}
+
+async fn record_auth_success(state: &AppState, ip: IpAddr) {
+    state.failed_attempts.lock().await.remove(&ip);
+}
+
+/// Verifies the ESPHome-style nonce/cnonce challenge-response before letting a request
+/// reach `handle_upload` - the password itself never has to be sent by the client.
+async fn require_valid_nonce(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    req: Request,
+    next: Next,
+) -> Response {
+    let ip = addr.ip();
+
+    if is_locked_out(&state, ip).await {
+        warn!("OTA: rejecting {ip}, locked out after repeated auth failures");
+        return (StatusCode::TOO_MANY_REQUESTS, "too many failed attempts").into_response();
+    }
+
+    let headers_present = (|| {
+        let nonce = headers.get("x-ota-nonce")?.to_str().ok()?.to_string();
+        let cnonce = headers.get("x-ota-cnonce")?.to_str().ok()?.to_string();
+        let auth = headers.get("x-ota-auth")?.to_str().ok()?.to_string();
+        Some((nonce, cnonce, auth))
+    })();
+
+    let Some((nonce, cnonce, auth)) = headers_present else {
+        return (StatusCode::UNAUTHORIZED, "missing OTA auth headers").into_response();
+    };
+
+    // Single-use: removed the instant it's looked up, whether or not it turns out valid,
+    // so a captured request/response pair can't be replayed.
+    let nonce_was_valid = {
+        let mut nonces = state.nonces.lock().await;
+        match nonces.remove(&nonce) {
+            Some(issued_at) => issued_at.elapsed() < NONCE_TTL,
+            None => false,
+        }
+    };
+
+    if !nonce_was_valid {
+        record_auth_failure(&state, ip).await;
+        return (StatusCode::UNAUTHORIZED, "unknown or expired nonce").into_response();
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(state.config.ota.password.as_bytes());
+    hasher.update(nonce.as_bytes());
+    hasher.update(cnonce.as_bytes());
+    let expected = hasher.finalize();
+
+    let provided = match hex::decode(&auth) {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            record_auth_failure(&state, ip).await;
+            return (StatusCode::UNAUTHORIZED, "malformed auth digest").into_response();
+        }
+    };
+
+    let digest_matches =
+        provided.len() == expected.len() && provided.ct_eq(&expected).unwrap_u8() == 1;
+
+    if !digest_matches {
+        record_auth_failure(&state, ip).await;
+        return (StatusCode::UNAUTHORIZED, "auth digest mismatch").into_response();
+    }
+
+    record_auth_success(&state, ip).await;
+
+    next.run(req).await
+}
+
+async fn handle_upload(headers: HeaderMap, body: Bytes) -> Response {
+    if body.len() < MIN_BINARY_SIZE {
+        return (StatusCode::BAD_REQUEST, "binary too small").into_response();
+    }
+
+    let Some(expected_sha256) = headers.get("x-ota-sha256").and_then(|v| v.to_str().ok()) else {
+        return (StatusCode::BAD_REQUEST, "missing X-OTA-Sha256 header").into_response();
+    };
+
+    let mut hasher = Sha256::new();
+    hasher.update(&body);
+    let actual_sha256 = hex::encode(hasher.finalize());
+
+    if !actual_sha256.eq_ignore_ascii_case(expected_sha256) {
+        warn!("OTA: checksum mismatch, refusing to apply binary");
+        return (StatusCode::BAD_REQUEST, "checksum mismatch").into_response();
+    }
+
+    if let Some(target) = headers.get("x-ota-target").and_then(|v| v.to_str().ok()) {
+        if target != current_platform::CURRENT_PLATFORM {
+            warn!(
+                "OTA: target mismatch, expected {} got {target}",
+                current_platform::CURRENT_PLATFORM
+            );
+            return (
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "target mismatch: device is {}",
+                    current_platform::CURRENT_PLATFORM
+                ),
+            )
+                .into_response();
+        }
+    }
+
+    info!("OTA: applying verified update ({} bytes)", body.len());
+
+    let bytes = body.to_vec();
+    let apply_result = tokio::task::spawn_blocking(move || {
+        ubihome_core::features::self_update::apply_new_binary(&bytes)
+    })
+    .await;
+
+    match apply_result {
+        Ok(Ok(())) => {
+            info!("OTA: update applied, restarting");
+            // Give the response a moment to flush before the process exits. The
+            // supervisor (systemd `Restart=always`, or the Windows SCM recovery
+            // action configured at install time) brings the process back up on the
+            // new binary; returning Err from `run()` here is not an option, since
+            // the runtime's task supervisor treats a module error as fatal.
+            tokio::spawn(async {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                std::process::exit(0);
+            });
+            (StatusCode::OK, Json(json!({ "status": "accepted" }))).into_response()
+        }
+        Ok(Err(e)) => {
+            error!("OTA: failed to apply update: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("failed to apply update: {e}"),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            error!("OTA: update task panicked: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal error applying update",
+            )
+                .into_response()
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct UbiHomePlatform {
+    config: CoreConfig,
+}
+
+impl Module for UbiHomePlatform {
+    fn new(config_string: &str, config_path: &str) -> Result<Self, String> {
+        let config =
+            ubihome_core::validation::validate_config::<CoreConfig>(config_string, config_path)?;
+
+        Ok(UbiHomePlatform { config })
+    }
+
+    fn components(&mut self) -> Vec<UbiComponent> {
+        Vec::new()
+    }
+
+    fn run(
+        &self,
+        _sender: Sender<ChangedMessage>,
+        _receiver: Receiver<PublishedMessage>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static>>
+    {
+        let config = self.config.clone();
+        info!("Starting OTA receiver on port {}", config.ota.port);
+
+        Box::pin(async move {
+            let max_binary_size = config.ota.max_binary_size as usize;
+            let app_state = Arc::new(AppState {
+                config: config.clone(),
+                nonces: Mutex::new(HashMap::new()),
+                failed_attempts: Mutex::new(HashMap::new()),
+            });
+
+            let upload_route = post(handle_upload)
+                .layer(DefaultBodyLimit::max(max_binary_size))
+                .route_layer(middleware::from_fn_with_state(
+                    app_state.clone(),
+                    require_valid_nonce,
+                ));
+
+            let app = Router::new()
+                .route("/challenge", get(handle_challenge))
+                .route("/upload", upload_route)
+                .with_state(app_state);
+
+            let addr: SocketAddr = format!("0.0.0.0:{}", config.ota.port).parse().unwrap();
+            let socket = TcpSocket::new_v4().unwrap();
+            socket.set_reuseaddr(true).unwrap();
+            socket.bind(addr).unwrap();
+            let listener = socket.listen(128).unwrap();
+
+            info!("OTA listening on http://{addr}");
+
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await?;
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ota_config_parsing() {
+        let config = r#"
+ubihome:
+  name: "Test OTA Config"
+
+ota:
+  port: 3333
+  password: "01234567890123456789012345678901"
+"#;
+
+        let ota_module = UbiHomePlatform::new(config, "config.yml");
+        assert!(ota_module.is_ok(), "OTA module should parse successfully");
+
+        let module = ota_module.unwrap();
+        assert_eq!(module.config.ota.port, 3333, "Port should be 3333");
+    }
+
+    #[test]
+    fn test_ota_config_defaults() {
+        let config = r#"
+ubihome:
+  name: "Test OTA Config"
+
+ota:
+  password: "01234567890123456789012345678901"
+"#;
+
+        let ota_module = UbiHomePlatform::new(config, "config.yml");
+        assert!(ota_module.is_ok(), "OTA module should parse successfully");
+
+        let module = ota_module.unwrap();
+        assert_eq!(module.config.ota.port, 3232, "Port should default to 3232");
+        assert_eq!(
+            module.config.ota.max_binary_size, 200_000_000,
+            "max_binary_size should default to 200_000_000"
+        );
+    }
+
+    #[test]
+    fn test_ota_config_rejects_short_password() {
+        let config = r#"
+ubihome:
+  name: "Test OTA Config"
+
+ota:
+  password: "tooshort"
+"#;
+
+        let ota_module = UbiHomePlatform::new(config, "config.yml");
+        assert!(
+            ota_module.is_err(),
+            "OTA module should reject a password shorter than 32 characters"
+        );
+    }
+}

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,4 +1,4 @@
-use std::{cmp::min, env};
+use std::cmp::min;
 
 use inquire::Confirm;
 use log::debug;
@@ -176,18 +176,10 @@ pub(crate) fn update(include_pre_release: bool) -> Result<(), String> {
         }
 
         pb.finish_with_message(format!("Downloaded {}", download_file_name));
-        match env::current_exe() {
-            Ok(exe_path) => {
-                let mut new_exe_path = exe_path.clone();
-                new_exe_path.set_file_name(format!("new_{}", new_exe_path.file_name().unwrap_or_default().to_string_lossy()));
-                std::fs::write(&new_exe_path, body_data).expect("Failed to create temporary file");
-
-                print!("Updating {}. ", exe_path.display());
-                self_replace::self_replace(&new_exe_path).unwrap();
-                std::fs::remove_file(&new_exe_path).unwrap();
-                println!("Updated!");
-            }
-            Err(e) => println!("failed to get current exe path: {e}"),
+        println!("Updating...");
+        match ubihome_core::features::self_update::apply_new_binary(&body_data) {
+            Ok(()) => println!("Updated!"),
+            Err(e) => return Err(format!("Failed to apply update: {e}")),
         };
         Ok(())
 


### PR DESCRIPTION
Adds a new `ota` platform component modeled on ESPHome's OTA update protocol: a server can push a new build to the device over HTTP instead of the device pulling releases from GitHub. Auth mirrors ESPHome's real scheme (SHA256(password || server_nonce || client_nonce) over a single-use, short-lived nonce from GET /challenge), so the password never crosses the wire and captured requests can't be replayed. POST /upload additionally verifies a SHA-256 body checksum before applying the update via the shared self_update helper and exiting so the process supervisor restarts on the new binary.

Also extracts the temp-file-write + self_replace + cleanup sequence from the interactive `ubihome update` CLI command into a shared `ubihome_core::features::self_update::apply_new_binary` helper (behind a new `self_update` feature on ubihome-core), so there's a single place that can brick a device instead of two divergent copies.

The pusher/server side that would actually drive this is future work.