### PR TITLE
feat(actions): add delay action

### DIFF
--- a/components/core/src/configuration/binary_sensor.rs
+++ b/components/core/src/configuration/binary_sensor.rs
@@ -35,6 +35,11 @@ pub enum ActionType {
 
     #[serde(rename = "button.press")]
     ButtonPress(#[garde(ascii)] String),
+
+    /// Pauses the action list for the configured duration before running the
+    /// next action.
+    #[serde(rename = "delay", deserialize_with = "deserialize_duration")]
+    Delay(#[garde(skip)] Duration),
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Validate)]

--- a/documentation/src/content/docs/features/components/actions.md
+++ b/documentation/src/content/docs/features/components/actions.md
@@ -36,5 +36,18 @@ See [Filters](/features/components/filters/) for the available debounce filters.
 | `switch.turn_on`  | switch `id` | Turns the referenced [switch](/features/entities/switch/) on.  |
 | `switch.turn_off` | switch `id` | Turns the referenced [switch](/features/entities/switch/) off. |
 | `button.press`    | button `id` | Presses the referenced [button](/features/entities/button/), running its platform action. |
+| `delay`           | duration    | Pauses the action list for the given duration (e.g. `2s`, `500ms`) before running the next action. |
 
-The argument is the `id` of the target entity, so make sure the switch or button you reference has an `id` set.
+For entity actions the argument is the `id` of the target entity, so make sure the switch or button you reference has an `id` set.
+
+```yaml
+binary_sensor:
+  - platform: gpio
+    name: 'Button'
+    pin: 17
+    on_press:
+      then:
+        - switch.turn_on: screen
+        - delay: 30s
+        - switch.turn_off: screen
+```

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -3,7 +3,7 @@ use crate::config::{get_platforms_from_config, BaseConfig, BaseConfigContext};
 use flexi_logger::writers::FileLogWriter;
 use flexi_logger::{detailed_format, Age, Cleanup, Criterion, Duplicate, FileSpec, Logger, Naming};
 
-use ubihome_core::configuration::binary_sensor::{ActionType, FilterType};
+use ubihome_core::configuration::binary_sensor::{Action, ActionType, FilterType};
 use ubihome_core::configuration::sensor::SensorFilterType;
 use ubihome_core::internal::sensors::UbiComponent;
 use ubihome_core::{ChangedMessage, PublishedMessage};
@@ -17,6 +17,42 @@ use std::sync::mpsc;
 use std::time::Duration;
 use tokio::sync::broadcast;
 use tokio::{runtime::Runtime, signal};
+
+/// Runs a trigger's list of actions in order.
+///
+/// Actions are executed sequentially so that a `delay` action pauses the list
+/// before the following actions run.
+async fn run_actions(actions: Vec<Action>, internal_tx: &broadcast::Sender<PublishedMessage>) {
+    for action in actions {
+        match &action.action {
+            ActionType::SwitchTurnOn(key) => {
+                let pcmd = PublishedMessage::SwitchStateCommand {
+                    key: key.clone(),
+                    state: true,
+                };
+                debug!("Publishing command from action {:?}: {:?}", action, pcmd);
+                internal_tx.send(pcmd).unwrap();
+            }
+            ActionType::SwitchTurnOff(key) => {
+                let pcmd = PublishedMessage::SwitchStateCommand {
+                    key: key.clone(),
+                    state: false,
+                };
+                debug!("Publishing command from action {:?}: {:?}", action, pcmd);
+                internal_tx.send(pcmd).unwrap();
+            }
+            ActionType::ButtonPress(key) => {
+                let pcmd = PublishedMessage::ButtonPressed { key: key.clone() };
+                debug!("Publishing command from action {:?}: {:?}", action, pcmd);
+                internal_tx.send(pcmd).unwrap();
+            }
+            ActionType::Delay(duration) => {
+                trace!("delay");
+                tokio::time::sleep(*duration).await;
+            }
+        }
+    }
+}
 
 fn read_base_config(path: &str) -> Result<String, String> {
     if !path.is_empty() {
@@ -162,8 +198,6 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
     // Spawn the root task
     let rt = Runtime::new().unwrap();
     rt.block_on(async {
-
-
         let (internal_tx, modules_rx) = broadcast::channel::<PublishedMessage>(16);
         let (modules_tx, mut internal_rx) = broadcast::channel::<ChangedMessage>(16);
 
@@ -174,7 +208,8 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
         let mut supervised_tasks: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
 
         // Double Option Workaround for https://github.com/Pauan/rust-signals/issues/75
-        let mut signal_map_binary_sensor: HashMap<String, Mutable<Option<Option<bool>>>> = HashMap::new();
+        let mut signal_map_binary_sensor: HashMap<String, Mutable<Option<Option<bool>>>> =
+            HashMap::new();
         let mut signal_map_sensor: HashMap<String, Mutable<Option<Option<f32>>>> = HashMap::new();
 
         for component in initialized_platforms.clone() {
@@ -184,8 +219,7 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
                 }
                 UbiComponent::Sensor(sensor) => {
                     let mutable: Mutable<Option<Option<f32>>> = Mutable::new(Option::None);
-                    signal_map_sensor
-                        .insert(sensor.id.clone(), mutable.clone());
+                    signal_map_sensor.insert(sensor.id.clone(), mutable.clone());
                     let internal_tx_clone = internal_tx.clone();
 
                     let mutable_clone = mutable.clone();
@@ -198,17 +232,18 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
                                 SensorFilterType::Round(decimals) => {
                                     trace!("round");
                                     signal = signal
-                                    .map(move |value| {
-                                        if let Some(v) = value.and_then(|v| v) {
-                                            // let number: f64 = v.parse().unwrap();
-                                            let output: f32 = format!("{:.1$}", v, decimals).parse().unwrap();
-                                            debug!("Round: {}", output);
-                                            Some(Some(output))
-                                        } else {
-                                            value
-                                        }
-                                    })
-                                    .boxed();
+                                        .map(move |value| {
+                                            if let Some(v) = value.and_then(|v| v) {
+                                                // let number: f64 = v.parse().unwrap();
+                                                let output: f32 =
+                                                    format!("{:.1$}", v, decimals).parse().unwrap();
+                                                debug!("Round: {}", output);
+                                                Some(Some(output))
+                                            } else {
+                                                value
+                                            }
+                                        })
+                                        .boxed();
                                 }
                             }
                         }
@@ -220,17 +255,13 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
 
                                 let key = sensor.id.clone();
                                 if let Some(value) = value.and_then(|v| v) {
-                                    let pcmd = PublishedMessage::SensorValueChanged {
-                                        key,
-                                        value,
-                                    };
+                                    let pcmd = PublishedMessage::SensorValueChanged { key, value };
                                     debug!("Publishing command from signal: {:?}", pcmd);
 
                                     signal_tx_clone.send(pcmd).unwrap();
                                 }
 
-                                async move {
-                                }
+                                async move {}
                             })
                             .await;
                     });
@@ -249,8 +280,7 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
                 }
                 UbiComponent::BinarySensor(binary_sensor) => {
                     let mutable: Mutable<Option<Option<bool>>> = Mutable::new(Option::None);
-                    signal_map_binary_sensor
-                        .insert(binary_sensor.id.clone(), mutable.clone());
+                    signal_map_binary_sensor.insert(binary_sensor.id.clone(), mutable.clone());
                     let internal_tx_clone = internal_tx.clone();
 
                     let mutable_clone = mutable.clone();
@@ -319,84 +349,31 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
 
                         // React to signal changes
                         signal
-                            .for_each(|value| {
+                            .for_each(move |value| {
+                                let action_tx = internal_tx_clone.clone();
                                 let signal_tx_clone = internal_tx_clone.clone();
 
                                 let key = binary_sensor.id.clone();
-                                if let Some(value) = value.and_then(|v| v) {
-                                    if value {
-                                        if let Some(on_press) = binary_sensor.on_press.clone() {
-                                            for action in on_press.then {
-                                                match &action.action {
-                                                    ActionType::SwitchTurnOn(key) => {
-                                                        let pcmd = PublishedMessage::SwitchStateCommand {
-                                                            key: key.clone(),
-                                                            state: true,
-                                                        };
-                                                        debug!("Publishing command from action {:?}: {:?}", action.clone(), pcmd);
-                                                        internal_tx_clone.send(pcmd).unwrap();
-                                                    }
-                                                    ActionType::SwitchTurnOff(key) => {
-                                                        let pcmd = PublishedMessage::SwitchStateCommand {
-                                                            key: key.clone(),
-                                                            state: false,
-                                                        };
-                                                        debug!("Publishing command from action {:?}: {:?}", action.clone(), pcmd);
-                                                        internal_tx_clone.send(pcmd).unwrap();
-                                                    }
-                                                    ActionType::ButtonPress(key) => {
-                                                        let pcmd = PublishedMessage::ButtonPressed {
-                                                            key: key.clone(),
-                                                        };
-                                                        debug!("Publishing command from action {:?}: {:?}", action.clone(), pcmd);
-                                                        internal_tx_clone.send(pcmd).unwrap();
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }else{
-                                        if let Some(on_release) = binary_sensor.on_release.clone() {
-                                            for action in on_release.then {
-                                                match &action.action {
-                                                    ActionType::SwitchTurnOn(key) => {
-                                                        let pcmd = PublishedMessage::SwitchStateCommand {
-                                                            key: key.clone(),
-                                                            state: true,
-                                                        };
-                                                        debug!("Publishing command from action {:?}: {:?}", action.clone(), pcmd);
-                                                        internal_tx_clone.send(pcmd).unwrap();
-                                                    }
-                                                    ActionType::SwitchTurnOff(key) => {
-                                                        let pcmd = PublishedMessage::SwitchStateCommand {
-                                                            key: key.clone(),
-                                                            state: false,
-                                                        };
-                                                        debug!("Publishing command from action {:?}: {:?}", action.clone(), pcmd);
-                                                        internal_tx_clone.send(pcmd).unwrap();
-                                                    }
-                                                    ActionType::ButtonPress(key) => {
-                                                        let pcmd = PublishedMessage::ButtonPressed {
-                                                            key: key.clone(),
-                                                        };
-                                                        debug!("Publishing command from action {:?}: {:?}", action.clone(), pcmd);
-                                                        internal_tx_clone.send(pcmd).unwrap();
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-
-
-                                    let pcmd = PublishedMessage::BinarySensorValueChanged {
-                                        key,
-                                        value,
-                                    };
-                                    debug!("Publishing command from signal: {:?}", pcmd);
-
-                                    signal_tx_clone.send(pcmd).unwrap();
-                                }
-
+                                let on_press = binary_sensor.on_press.clone();
+                                let on_release = binary_sensor.on_release.clone();
                                 async move {
+                                    if let Some(value) = value.and_then(|v| v) {
+                                        if value {
+                                            if let Some(on_press) = on_press {
+                                                run_actions(on_press.then, &action_tx).await;
+                                            }
+                                        } else if let Some(on_release) = on_release {
+                                            run_actions(on_release.then, &action_tx).await;
+                                        }
+
+                                        let pcmd = PublishedMessage::BinarySensorValueChanged {
+                                            key,
+                                            value,
+                                        };
+                                        debug!("Publishing command from signal: {:?}", pcmd);
+
+                                        signal_tx_clone.send(pcmd).unwrap();
+                                    }
                                 }
                             })
                             .await;
@@ -427,12 +404,36 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
                         ChangedMessage::SwitchStateCommand { key, state } => {
                             Some(PublishedMessage::SwitchStateCommand { key, state })
                         }
-                        ChangedMessage::LightStateChange { key, state, brightness, red, green, blue } => {
-                            Some(PublishedMessage::LightStateChange { key, state, brightness, red, green, blue })
-                        }
-                        ChangedMessage::LightStateCommand { key, state, brightness, red, green, blue } => {
-                            Some(PublishedMessage::LightStateCommand { key, state, brightness, red, green, blue })
-                        }
+                        ChangedMessage::LightStateChange {
+                            key,
+                            state,
+                            brightness,
+                            red,
+                            green,
+                            blue,
+                        } => Some(PublishedMessage::LightStateChange {
+                            key,
+                            state,
+                            brightness,
+                            red,
+                            green,
+                            blue,
+                        }),
+                        ChangedMessage::LightStateCommand {
+                            key,
+                            state,
+                            brightness,
+                            red,
+                            green,
+                            blue,
+                        } => Some(PublishedMessage::LightStateCommand {
+                            key,
+                            state,
+                            brightness,
+                            red,
+                            green,
+                            blue,
+                        }),
                         ChangedMessage::ButtonPress { key } => {
                             Some(PublishedMessage::ButtonPressed { key })
                         }
@@ -490,9 +491,7 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
                             UbiComponent::BinarySensor(binary_sensor.clone())
                         }
                         UbiComponent::Light(light) => UbiComponent::Light(light.clone()),
-                        UbiComponent::Number(number) => {
-                            UbiComponent::Number(number.clone())
-                        }
+                        UbiComponent::Number(number) => UbiComponent::Number(number.clone()),
                         UbiComponent::TextSensor(text_sensor) => {
                             UbiComponent::TextSensor(text_sensor.clone())
                         }

--- a/tests/internal/trigger_action_test.py
+++ b/tests/internal/trigger_action_test.py
@@ -84,3 +84,58 @@ binary_sensor:
     async with UbiHome("run", config=DEVICE_INFO_CONFIG):
         sensor_mock.set_value("false")
         button_mock.wait_for_mock_state("pressed")
+
+
+async def test_binary_sensor_delay_action(io_mock_factory: IOMockFactory):
+    """
+    Test that the `delay` action pauses an action list without aborting it: the
+    action before the delay (turning a switch on) and the action after the delay
+    (pressing a button) both run.
+    """
+
+    switch_mock = io_mock_factory.create_mock()
+    button_mock = io_mock_factory.create_mock()
+    sensor_mock = io_mock_factory.create_mock()
+
+    DEVICE_INFO_CONFIG = f"""
+ubihome:
+  name: test_device
+
+shell:
+
+switch:
+  - platform: shell
+    name: "Test Switch"
+    id: test_switch
+    command_on: "echo true > {switch_mock}"
+    command_off: "echo false > {switch_mock}"
+    command_state: "cat {switch_mock} || echo false"
+
+button:
+  - platform: shell
+    name: "Test Button"
+    id: test_button
+    command: "echo pressed > {button_mock}"
+
+binary_sensor:
+  - platform: shell
+    name: "Test Binary Sensor"
+    update_interval: 2s
+    command: |-
+      cat {sensor_mock}
+    on_press:
+      then:
+        - switch.turn_on: "test_switch"
+        - delay: 1s
+        - button.press: "test_button"
+"""
+    switch_mock.set_value("false")
+    sensor_mock.set_value("false")
+
+    async with UbiHome("run", config=DEVICE_INFO_CONFIG):
+        sensor_mock.set_value("true")
+        # Action before the delay turns the switch on.
+        switch_mock.wait_for_mock_state("true")
+        # Action after the delay presses the button, proving the delay does not
+        # abort the remaining actions in the list.
+        button_mock.wait_for_mock_state("pressed")


### PR DESCRIPTION
## Summary

Adds a `delay` action that can be used inside a trigger's `then` list to pause for a configured duration before running the following actions.

```yaml
binary_sensor:
  - platform: gpio
    name: 'Button'
    pin: 17
    on_press:
      then:
        - switch.turn_on: screen
        - delay: 30s
        - switch.turn_off: screen
```

The argument accepts any duration string (`2s`, `500ms`, etc.).

## Changes

- **`components/core/src/configuration/binary_sensor.rs`** — add `ActionType::Delay(Duration)` (serialized as `delay`, parsed via `deserialize_duration`).
- **`src/commands/run.rs`** — the on_press/on_release action loops previously ran synchronously in the signal handler, so an action could not `await`. Factored the two duplicated loops into a shared `async fn run_actions(...)` and moved execution into the async handler block so `delay` can sleep between actions.
- **`documentation/src/content/docs/features/components/actions.md`** — document the action and add an example.
- **`tests/internal/trigger_action_test.py`** — add `test_binary_sensor_delay_action` verifying the actions before and after the delay both run.

## Notes

- `run.rs` has a larger diff than the logical change: rustfmt had been silently bailing on the original file due to some deeply-nested overlong `debug!` lines. Removing them (as part of the refactor) let rustfmt format the whole file, so a few adjacent blocks were tidied to keep `cargo fmt --check` green.

## Testing

- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `pytest internal/trigger_action_test.py` → 3 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7LypGLd2gX56ZK6QBXdWz)_