### PR TITLE
feat(core): use global state

### DIFF
--- a/components/api/src/lib.rs
+++ b/components/api/src/lib.rs
@@ -39,7 +39,10 @@ use ubihome_core::features::ip::get_ip_address;
 use ubihome_core::features::ip::get_network_mac_address;
 use ubihome_core::NoConfig;
 use ubihome_core::{
-    config_template, internal::sensors::UbiComponent, ChangedMessage, Module, PublishedMessage,
+    config_template,
+    internal::sensors::UbiComponent,
+    state::{EntityState, StateStore},
+    ChangedMessage, Module, PublishedMessage,
 };
 
 use ubihome_core::constants::is_readable_string_option;
@@ -126,7 +129,8 @@ impl Module for UbiHomePlatform {
     fn run(
         &self,
         sender: Sender<ChangedMessage>,
-        mut receiver: Receiver<PublishedMessage>,
+        receiver: Receiver<PublishedMessage>,
+        state: StateStore,
     ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static>>
     {
         let ip = get_ip_address().unwrap();
@@ -184,7 +188,8 @@ impl Module for UbiHomePlatform {
         info!("Starting API with config: {:?}", config.api);
 
         Box::pin(async move {
-            if let Ok(PublishedMessage::Components { components }) = receiver.recv().await {
+            {
+                let components = state.components().to_vec();
                 for component in components {
                     match component {
                         UbiComponent::Switch(switch_entity) => {
@@ -357,8 +362,10 @@ impl Module for UbiHomePlatform {
                 let server = server_base.clone();
                 let mut receiver_clone = receiver.resubscribe();
                 let api_components_key_id_clone = api_components_key_id.clone();
+                let api_components_key_id_clone_for_subscribe = api_components_key_id.clone();
                 let api_components_clone = api_components_by_key.clone();
                 let cloned_sender = sender.clone();
+                let state_clone = state.clone();
                 tokio::spawn({
                     async move {
                         debug!("Accepted request from {}", socket.peer_addr().unwrap());
@@ -592,6 +599,92 @@ impl Module for UbiHomePlatform {
                                             "SubscribeStatesRequest: {:?}",
                                             subscribe_states_request
                                         );
+                                        for (entity_key, entity_state) in state_clone.snapshot() {
+                                            let Some(key) = api_components_key_id_clone_for_subscribe
+                                                .get(&entity_key)
+                                            else {
+                                                continue;
+                                            };
+                                            let message = match entity_state {
+                                                EntityState::Switch(state) => {
+                                                    ProtoMessage::SwitchStateResponse(
+                                                        SwitchStateResponse {
+                                                            key: *key,
+                                                            device_id: 0,
+                                                            state,
+                                                        },
+                                                    )
+                                                }
+                                                EntityState::BinarySensor(state) => {
+                                                    ProtoMessage::BinarySensorStateResponse(
+                                                        BinarySensorStateResponse {
+                                                            key: *key,
+                                                            device_id: 0,
+                                                            state,
+                                                            missing_state: false,
+                                                        },
+                                                    )
+                                                }
+                                                EntityState::Sensor(state) => {
+                                                    ProtoMessage::SensorStateResponse(
+                                                        SensorStateResponse {
+                                                            key: *key,
+                                                            device_id: 0,
+                                                            state,
+                                                            missing_state: false,
+                                                        },
+                                                    )
+                                                }
+                                                EntityState::Number(state) => {
+                                                    ProtoMessage::NumberStateResponse(
+                                                        NumberStateResponse {
+                                                            key: *key,
+                                                            device_id: 0,
+                                                            state,
+                                                            missing_state: false,
+                                                        },
+                                                    )
+                                                }
+                                                EntityState::TextSensor(state) => {
+                                                    ProtoMessage::TextSensorStateResponse(
+                                                        TextSensorStateResponse {
+                                                            key: *key,
+                                                            device_id: 0,
+                                                            state,
+                                                            missing_state: false,
+                                                        },
+                                                    )
+                                                }
+                                                EntityState::Light {
+                                                    state,
+                                                    brightness,
+                                                    red,
+                                                    green,
+                                                    blue,
+                                                } => ProtoMessage::LightStateResponse(
+                                                    LightStateResponse {
+                                                        key: *key,
+                                                        device_id: 0,
+                                                        state,
+                                                        brightness: brightness.unwrap_or(0.0),
+                                                        color_mode: 1,
+                                                        color_brightness: brightness
+                                                            .unwrap_or(0.0),
+                                                        red: red.unwrap_or(0.0),
+                                                        green: green.unwrap_or(0.0),
+                                                        blue: blue.unwrap_or(0.0),
+                                                        white: 0.0,
+                                                        color_temperature: 0.0,
+                                                        cold_white: 0.0,
+                                                        warm_white: 0.0,
+                                                        effect: "".to_string(),
+                                                    },
+                                                ),
+                                            };
+                                            if tx.send(message).await.is_err() {
+                                                break;
+                                            }
+                                        }
                                     }
                                     ProtoMessage::SubscribeHomeassistantServicesRequest(
                                         request,
@@ -740,8 +833,6 @@ impl Module for UbiHomePlatform {
 
 #[cfg(test)]
 mod tests {
-    use esphome_native_api::proto::ListEntitiesLightResponse;
-
     use super::*;
 
     #[test]
@@ -757,7 +848,7 @@ api:
 
 "#;
 
-        let api_module = UbiHomePlatform::new(&config.to_string());
+        let api_module = UbiHomePlatform::new(&config.to_string(), "config.yml");
         assert!(api_module.is_ok(), "API module should parse successfully");
 
         let module = api_module.unwrap();
@@ -780,7 +871,7 @@ ubihome:
 api: {}
 "#;
 
-        let api_module = UbiHomePlatform::new(&config.to_string());
+        let api_module = UbiHomePlatform::new(&config.to_string(), "config.yml");
         assert!(api_module.is_ok(), "API module should parse successfully");
 
         let module = api_module.unwrap();

--- a/components/api/src/lib.rs
+++ b/components/api/src/lib.rs
@@ -604,7 +604,7 @@ impl Module for UbiHomePlatform {
                                             "SubscribeStatesRequest: {:?}",
                                             subscribe_states_request
                                         );
-                                        for (entity_key, entity_state) in state_clone.snapshot() {
+                                        for (entity_key, entity_state) in state_clone.get_all() {
                                             let Some(key) =
                                                 api_components_key_id_clone_for_subscribe
                                                     .get(&entity_key)

--- a/components/api/src/lib.rs
+++ b/components/api/src/lib.rs
@@ -600,8 +600,9 @@ impl Module for UbiHomePlatform {
                                             subscribe_states_request
                                         );
                                         for (entity_key, entity_state) in state_clone.snapshot() {
-                                            let Some(key) = api_components_key_id_clone_for_subscribe
-                                                .get(&entity_key)
+                                            let Some(key) =
+                                                api_components_key_id_clone_for_subscribe
+                                                    .get(&entity_key)
                                             else {
                                                 continue;
                                             };
@@ -668,8 +669,7 @@ impl Module for UbiHomePlatform {
                                                         state,
                                                         brightness: brightness.unwrap_or(0.0),
                                                         color_mode: 1,
-                                                        color_brightness: brightness
-                                                            .unwrap_or(0.0),
+                                                        color_brightness: brightness.unwrap_or(0.0),
                                                         red: red.unwrap_or(0.0),
                                                         green: green.unwrap_or(0.0),
                                                         blue: blue.unwrap_or(0.0),
@@ -848,7 +848,7 @@ api:
 
 "#;
 
-        let api_module = UbiHomePlatform::new(&config.to_string(), "config.yml");
+        let api_module = UbiHomePlatform::new(config, "config.yml");
         assert!(api_module.is_ok(), "API module should parse successfully");
 
         let module = api_module.unwrap();
@@ -871,7 +871,7 @@ ubihome:
 api: {}
 "#;
 
-        let api_module = UbiHomePlatform::new(&config.to_string(), "config.yml");
+        let api_module = UbiHomePlatform::new(config, "config.yml");
         assert!(api_module.is_ok(), "API module should parse successfully");
 
         let module = api_module.unwrap();

--- a/components/bluetooth_proxy/src/lib.rs
+++ b/components/bluetooth_proxy/src/lib.rs
@@ -7,7 +7,8 @@ use std::collections::HashMap;
 use std::{future::Future, pin::Pin, str};
 use tokio::sync::broadcast::{Receiver, Sender};
 use ubihome_core::{
-    config_template, internal::sensors::UbiComponent, ChangedMessage, Module, PublishedMessage,
+    config_template, internal::sensors::UbiComponent, state::StateStore, ChangedMessage, Module,
+    PublishedMessage,
 };
 use ubihome_core::{BluetoothProxyMessage, NoConfig};
 
@@ -57,6 +58,7 @@ impl Module for UbiHomePlatform {
         &self,
         sender: Sender<ChangedMessage>,
         _: Receiver<PublishedMessage>,
+        _state: StateStore,
     ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static>>
     {
         let config = self.config.clone();

--- a/components/bme280/src/lib.rs
+++ b/components/bme280/src/lib.rs
@@ -6,6 +6,7 @@ use ubihome_core::{
     config_template,
     constants::{is_id_string_option, is_readable_string},
     internal::sensors::{UbiComponent, UbiSensor},
+    state::StateStore,
     template_sensor, with_base_entity_properties, ChangedMessage, Module, NoConfig,
     PublishedMessage,
 };
@@ -254,6 +255,7 @@ impl Module for UbiHomePlatform {
         &self,
         sender: Sender<ChangedMessage>,
         _: Receiver<PublishedMessage>,
+        _state: StateStore,
     ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static>>
     {
         // let mqtt_config = self.mqtt_config.clone();

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod constants;
 pub mod features;
 pub mod internal;
 pub mod mapper;
+pub mod state;
 pub mod text_sensor;
 pub mod utils;
 #[cfg(feature = "validation")]
@@ -16,6 +17,7 @@ use std::{collections::HashMap, future::Future, pin::Pin};
 use tokio::sync::broadcast::{Receiver, Sender};
 
 use crate::constants::{is_readable_string, is_readable_string_option};
+use crate::state::StateStore;
 
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 pub type ModuleRunFuture = BoxFuture<'static, Result<(), Box<dyn std::error::Error>>>;
@@ -39,6 +41,7 @@ where
         &self,
         sender: Sender<ChangedMessage>,
         receiver: Receiver<PublishedMessage>,
+        state: StateStore,
     ) -> ModuleRunFuture;
 }
 
@@ -107,9 +110,6 @@ pub enum ChangedMessage {
 
 #[derive(Debug, Clone)]
 pub enum PublishedMessage {
-    Components {
-        components: Vec<UbiComponent>,
-    },
     ButtonPressed {
         key: String,
     },

--- a/components/core/src/state.rs
+++ b/components/core/src/state.rs
@@ -42,7 +42,7 @@ impl StateStore {
             .cloned()
     }
 
-    pub fn snapshot(&self) -> HashMap<String, EntityState> {
+    pub fn get_all(&self) -> HashMap<String, EntityState> {
         self.entity_states
             .read()
             .expect("state store lock poisoned")

--- a/components/core/src/state.rs
+++ b/components/core/src/state.rs
@@ -1,0 +1,83 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use crate::internal::sensors::UbiComponent;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum EntityState {
+    Switch(bool),
+    BinarySensor(bool),
+    Sensor(f32),
+    Number(f32),
+    TextSensor(String),
+    Light {
+        state: bool,
+        brightness: Option<f32>,
+        red: Option<f32>,
+        green: Option<f32>,
+        blue: Option<f32>,
+    },
+}
+
+/// Read-only handle to the global entity/state cache. Every platform module
+/// receives one of these via [`crate::Module::run`]. There is no way to
+/// mutate the underlying data through this type - only [`StateStoreWriter`],
+/// which is never handed to modules, can do that.
+#[derive(Clone)]
+pub struct StateStore {
+    components: Arc<Vec<UbiComponent>>,
+    entity_states: Arc<RwLock<HashMap<String, EntityState>>>,
+}
+
+impl StateStore {
+    pub fn components(&self) -> &[UbiComponent] {
+        &self.components
+    }
+
+    pub fn get(&self, key: &str) -> Option<EntityState> {
+        self.entity_states
+            .read()
+            .expect("state store lock poisoned")
+            .get(key)
+            .cloned()
+    }
+
+    pub fn snapshot(&self) -> HashMap<String, EntityState> {
+        self.entity_states
+            .read()
+            .expect("state store lock poisoned")
+            .clone()
+    }
+}
+
+/// Owns write access to the global entity/state cache. Only the main
+/// application (`src/commands/run.rs`) should construct this - platform
+/// modules only ever see the read-only [`StateStore`] handed to them.
+/// `Clone` is for the main application's own internal tasks (which each
+/// write a different subset of entities) to share write access - it does
+/// not leak write access to platform modules, which never receive this type.
+#[derive(Clone)]
+pub struct StateStoreWriter {
+    entity_states: Arc<RwLock<HashMap<String, EntityState>>>,
+}
+
+impl StateStoreWriter {
+    /// The component list is topology: known before any module runs and
+    /// fixed for the lifetime of the process, so it is set once here rather
+    /// than mutated later.
+    pub fn new(components: Vec<UbiComponent>) -> (StateStoreWriter, StateStore) {
+        let entity_states = Arc::new(RwLock::new(HashMap::new()));
+        let store = StateStore {
+            components: Arc::new(components),
+            entity_states: entity_states.clone(),
+        };
+        (StateStoreWriter { entity_states }, store)
+    }
+
+    pub fn set(&self, key: String, state: EntityState) {
+        self.entity_states
+            .write()
+            .expect("state store lock poisoned")
+            .insert(key, state);
+    }
+}

--- a/components/evdev/src/lib.rs
+++ b/components/evdev/src/lib.rs
@@ -5,8 +5,7 @@ use std::{future::Future, pin::Pin, str};
 use tokio::sync::broadcast::{Receiver, Sender};
 use ubihome_core::internal::sensors::UbiComponent;
 use ubihome_core::{
-    config_template, internal::sensors::UbiBinarySensor, ChangedMessage, Module, NoConfig,
-    PublishedMessage,
+    config_template, state::StateStore, ChangedMessage, Module, NoConfig, PublishedMessage,
 };
 
 #[derive(Clone, Deserialize, Debug, Validate)]
@@ -43,41 +42,19 @@ impl Module for UbiHomePlatform {
     }
 
     fn components(&mut self) -> Vec<UbiComponent> {
-        let mut components: Vec<UbiComponent> = Vec::new();
-
-        for (_, any_sensor) in self.config.binary_sensor.clone().unwrap_or_default() {
-            match any_sensor.extra {
-                BinarySensorKind::evdev(_) => {
-                    let object_id = format!(
-                        "{}_{}",
-                        self.config.ubihome.name,
-                        &any_sensor.default.name.clone()
-                    );
-                    let id = &any_sensor.default.id.clone().unwrap_or(object_id.clone());
-                    components.push(UbiComponent::BinarySensor(UbiBinarySensor {
-                        platform: "sensor".to_string(),
-                        icon: any_sensor.default.icon.clone(),
-                        device_class: any_sensor.default.device_class.clone(),
-                        name: any_sensor.default.name.clone(),
-                        id: object_id.clone(),
-                        on_press: any_sensor.default.on_press.clone(),
-                        on_release: any_sensor.default.on_release.clone(),
-                        filters: any_sensor.default.filters.clone(),
-                    }));
-                }
-                _ => {}
-            }
-        }
-        components
+        // TODO: Add events? binary_sensor is currently wired to NoConfig
+        // (see config_template! below), so there is no evdev-specific config
+        // to build entities from yet.
+        Vec::new()
     }
 
     fn run(
         &self,
-        sender: Sender<ChangedMessage>,
+        _sender: Sender<ChangedMessage>,
         _: Receiver<PublishedMessage>,
+        _state: StateStore,
     ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static>>
     {
-        let config = self.config.clone();
         Box::pin(async move {
             #[cfg(any(target_os = "macos", target_os = "windows"))]
             {
@@ -94,29 +71,9 @@ impl Module for UbiHomePlatform {
                 //     println!(":(");
                 // }
 
-                if let Some(binary_sensors) = config.binary_sensor.clone() {
-                    for (key, binary_sensor) in binary_sensors {
-                        let cloned_sender = sender.clone();
-                        match binary_sensor.extra {
-                            BinarySensorKind::evdev(gpio_config) => {
-                                debug!("BinarySensor {} is of type evdev", key);
-
-                                // tokio::spawn(async move {
-                                //     let duration = gpio_config
-                                //         .update_interval
-                                //         .unwrap_or(Duration::from_secs(30));
-                                //     let mut interval = time::interval(duration);
-
-                                //     loop {
-                                //         interval.tick().await;
-
-                                //     }
-                                // });
-                            }
-                            _ => {}
-                        }
-                    }
-                }
+                // TODO: Add events? binary_sensor is currently wired to
+                // NoConfig (see config_template! below), so there is no
+                // evdev-specific config to read here yet.
             }
             Ok(())
         })

--- a/components/evdev/src/lib.rs
+++ b/components/evdev/src/lib.rs
@@ -29,6 +29,9 @@ config_template!(
 
 #[derive(Clone, Debug)]
 pub struct UbiHomePlatform {
+    // Reserved for when binary_sensor gets its own evdev config extension
+    // (see the TODO on config_template! below) instead of NoConfig.
+    #[allow(dead_code)]
     config: CoreConfig,
 }
 
@@ -38,7 +41,7 @@ impl Module for UbiHomePlatform {
             ubihome_core::validation::validate_config::<CoreConfig>(config_string, config_path)?;
 
         info!("Evdev config: {:?}", config);
-        Ok(UbiHomePlatform { config: config })
+        Ok(UbiHomePlatform { config })
     }
 
     fn components(&mut self) -> Vec<UbiComponent> {
@@ -75,7 +78,10 @@ impl Module for UbiHomePlatform {
                 // NoConfig (see config_template! below), so there is no
                 // evdev-specific config to read here yet.
             }
-            Ok(())
+            #[cfg(target_os = "linux")]
+            {
+                Ok(())
+            }
         })
     }
 }

--- a/components/gpio/src/lib.rs
+++ b/components/gpio/src/lib.rs
@@ -6,6 +6,7 @@ use tokio::sync::broadcast::{Receiver, Sender};
 use ubihome_core::constants::is_id_string_option;
 use ubihome_core::constants::is_readable_string;
 use ubihome_core::internal::sensors::{UbiComponent, UbiSwitch};
+use ubihome_core::state::StateStore;
 use ubihome_core::template_binary_sensor;
 use ubihome_core::template_switch;
 use ubihome_core::with_base_entity_properties;
@@ -188,6 +189,7 @@ impl Module for UbiHomePlatform {
         &self,
         #[allow(unused_variables)] sender: Sender<ChangedMessage>,
         #[allow(unused_variables, unused_mut)] mut receiver: Receiver<PublishedMessage>,
+        #[allow(unused_variables)] state: StateStore,
     ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static>>
     {
         #[allow(unused_variables)]

--- a/components/illuminance/src/lib.rs
+++ b/components/illuminance/src/lib.rs
@@ -10,6 +10,7 @@ use tokio::{
 use ubihome_core::constants::is_id_string_option;
 use ubihome_core::constants::is_readable_string;
 use ubihome_core::internal::sensors::UbiComponent;
+use ubihome_core::state::StateStore;
 use ubihome_core::template_sensor;
 use ubihome_core::with_base_entity_properties;
 use ubihome_core::{
@@ -110,6 +111,7 @@ impl Module for UbiHomePlatform {
         &self,
         sender: Sender<ChangedMessage>,
         _receiver: Receiver<PublishedMessage>,
+        _state: StateStore,
     ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static>>
     {
         let sensors = self.sensors.clone();

--- a/components/mdns/src/lib.rs
+++ b/components/mdns/src/lib.rs
@@ -8,7 +8,8 @@ use tokio::sync::broadcast::{Receiver, Sender};
 use ubihome_core::features::ip::{get_ip_address, get_network_mac_address};
 use ubihome_core::NoConfig;
 use ubihome_core::{
-    config_template, internal::sensors::UbiComponent, ChangedMessage, Module, PublishedMessage,
+    config_template, internal::sensors::UbiComponent, state::StateStore, ChangedMessage, Module,
+    PublishedMessage,
 };
 
 #[derive(Clone, Deserialize, Debug, Validate)]
@@ -55,6 +56,7 @@ impl Module for UbiHomePlatform {
         &self,
         _sender: Sender<ChangedMessage>,
         _: Receiver<PublishedMessage>,
+        _state: StateStore,
     ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static>>
     {
         let config = self.config.clone();

--- a/components/mqtt/src/lib.rs
+++ b/components/mqtt/src/lib.rs
@@ -117,7 +117,7 @@ impl Module for UbiHomePlatform {
                         // Internal components (configured with an
                         // id but no name) are not exposed over MQTT.
                         if component.is_internal() {
-                          continue;
+                            continue;
                         }
                         match component {
                             // TODO: Use object_id generator

--- a/components/mqtt/src/lib.rs
+++ b/components/mqtt/src/lib.rs
@@ -20,6 +20,7 @@ use ubihome_core::{
     config_template,
     features::ip::{get_ip_address, get_network_mac_address},
     internal::sensors::UbiComponent,
+    state::StateStore,
     ChangedMessage, Module, NoConfig, PublishedMessage,
 };
 
@@ -63,6 +64,7 @@ impl Module for UbiHomePlatform {
         &self,
         sender: Sender<ChangedMessage>,
         mut receiver: Receiver<PublishedMessage>,
+        state: StateStore,
     ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static>>
     {
         let config = self.config.clone();
@@ -106,218 +108,200 @@ impl Module for UbiHomePlatform {
 
             let all_mqtt_components_clone = all_mqtt_components.clone();
             tokio::spawn(async move {
+                {
+                    let components = state.components().to_vec();
+                    let mut mqtt_components: HashMap<String, HAMqttComponent> = HashMap::new();
+                    let mut topics: Vec<String> = vec![];
+
+                    for component in components {
+                        match component {
+                            // TODO: Use object_id generator
+                            // let id = sensor.unique_id.unwrap_or(format!(
+                            //     "{}_{}",
+                            //     core_config.ubihome.name, sensor.name
+                            // ));
+                            UbiComponent::Switch(switch) => {
+                                let topic = format!(
+                                    "{}/{}/set",
+                                    base_topic_clone.clone(),
+                                    switch.id.clone()
+                                );
+                                topics.push(topic.clone());
+
+                                mqtt_components.insert(
+                                    switch.id.clone(),
+                                    HAMqttComponent::Switch(HAMqttSwitch {
+                                        platform: "switch".to_string(),
+                                        unique_id: switch.id.clone(),
+                                        command_topic: topic,
+                                        state_topic: format!(
+                                            "{}/{}",
+                                            base_topic_clone.clone(),
+                                            switch.id.clone()
+                                        ),
+                                        name: switch.name.clone(),
+                                        icon: switch.icon.clone(),
+                                        object_id: switch.id.clone(),
+                                    }),
+                                );
+                            }
+                            UbiComponent::Button(button) => {
+                                let topic =
+                                    format!("{}/{}", base_topic_clone.clone(), button.id.clone());
+                                topics.push(topic.clone());
+                                mqtt_components.insert(
+                                    button.id.clone(),
+                                    HAMqttComponent::Button(HAMqttButton {
+                                        platform: "button".to_string(),
+                                        unique_id: button.id.clone(),
+                                        command_topic: topic,
+                                        name: button.name.clone(),
+                                        icon: button.icon.clone(),
+                                        object_id: button.id.clone(),
+                                    }),
+                                );
+                            }
+                            UbiComponent::Sensor(sensor) => {
+                                mqtt_components.insert(
+                                    sensor.id.clone(),
+                                    HAMqttComponent::Sensor(HAMqttSensor {
+                                        platform: "sensor".to_string(),
+                                        icon: sensor.icon.clone(),
+                                        unique_id: sensor.id.clone(),
+                                        device_class: sensor
+                                            .device_class
+                                            .clone()
+                                            .unwrap_or("".to_string()),
+                                        unit_of_measurement: sensor
+                                            .unit_of_measurement
+                                            .clone()
+                                            .unwrap_or("".to_string()),
+                                        name: sensor.name.clone(),
+                                        state_topic: format!(
+                                            "{}/{}",
+                                            base_topic_clone.clone(),
+                                            sensor.id.clone()
+                                        ),
+                                        object_id: sensor.id.clone(),
+                                    }),
+                                );
+                            }
+                            UbiComponent::BinarySensor(sensor) => {
+                                mqtt_components.insert(
+                                    sensor.id.clone(),
+                                    HAMqttComponent::BinarySensor(HAMqttBinarySensor {
+                                        platform: "binary_sensor".to_string(),
+                                        icon: sensor.icon.clone(),
+                                        unique_id: sensor.id.clone(),
+                                        device_class: sensor
+                                            .device_class
+                                            .clone()
+                                            .unwrap_or("".to_string()),
+                                        name: sensor.name.clone(),
+                                        state_topic: format!(
+                                            "{}/{}",
+                                            base_topic_clone.clone(),
+                                            sensor.id.clone()
+                                        ),
+                                        object_id: sensor.id.clone(),
+                                    }),
+                                );
+                            }
+                            UbiComponent::Light(_light) => {
+                                // TODO: Add MQTT light support if needed
+                                // For now, just skip light components for MQTT
+                            }
+                            UbiComponent::Number(number) => {
+                                let state_topic =
+                                    format!("{}/{}", base_topic_clone.clone(), number.id.clone());
+                                let command_topic = format!(
+                                    "{}/{}/set",
+                                    base_topic_clone.clone(),
+                                    number.id.clone()
+                                );
+                                topics.push(command_topic.clone());
+
+                                mqtt_components.insert(
+                                    number.id.clone(),
+                                    HAMqttComponent::Number(HAMqttNumber {
+                                        platform: "number".to_string(),
+                                        unique_id: number.id.clone(),
+                                        command_topic,
+                                        state_topic,
+                                        name: number.name.clone(),
+                                        icon: number.icon.clone(),
+                                        object_id: number.id.clone(),
+                                        min: number.min_value,
+                                        max: number.max_value,
+                                        step: number.step,
+                                        unit_of_measurement: number
+                                            .unit_of_measurement
+                                            .clone()
+                                            .filter(|s| !s.is_empty()),
+                                    }),
+                                );
+                            }
+                            UbiComponent::TextSensor(_text_sensor) => {
+                                // TODO: Add MQTT text sensor support if needed
+                            }
+                        }
+                    }
+                    {
+                        let mut all_mqtt_components = all_mqtt_components_clone.write().await;
+                        all_mqtt_components.extend(mqtt_components.clone());
+                        debug!("MQTT Components: {:?}", mqtt_components.keys());
+                    }
+
+                    let ip = get_ip_address().unwrap();
+                    let mac = get_network_mac_address(ip).unwrap();
+                    let device = HAMqttDevice {
+                        identifiers: vec![config.ubihome.name.clone()],
+                        manufacturer: format!(
+                            "{} {} {}",
+                            whoami::platform(),
+                            whoami::distro(),
+                            whoami::arch()
+                        ),
+                        name: config.ubihome.name.clone(),
+                        model: whoami::devicename(),
+                        connections: vec![HAMqttConnection {
+                            r#type: "mac".to_string(),
+                            value: mac,
+                        }],
+                    };
+
+                    let origin = HAMqttOrigin {
+                        name: "ubihome".to_string(),
+                        sw: "0.1".to_string(),
+                        url: "https://test.com".to_string(),
+                    };
+
+                    let discovery_message = HAMqttDiscoveryMessage {
+                        device,
+                        origin,
+                        components: mqtt_components.clone(),
+                    };
+                    let discovery_payload = serde_json::to_string(&discovery_message).unwrap();
+
+                    debug!("Publishing discovery message to topic: {}", discovery_topic);
+                    debug!("Discovery payload: {}", discovery_payload);
+                    client
+                        .publish(&discovery_topic, QoS::AtLeastOnce, false, discovery_payload)
+                        .await
+                        .unwrap();
+
+                    debug!("Discovery message published successfully");
+
+                    // Subscribe to the discovery topic
+                    for topic in topics {
+                        debug!("Subscribing to topic: {}", topic);
+                        client.subscribe(&topic, QoS::AtLeastOnce).await.unwrap();
+                    }
+                }
                 loop {
                     match receiver.recv().await {
                         Ok(cmd) => {
                             match cmd {
-                                PublishedMessage::Components { components } => {
-                                    let mut mqtt_components: HashMap<String, HAMqttComponent> =
-                                        HashMap::new();
-                                    let mut topics: Vec<String> = vec![];
-
-                                    for component in components {
-                                        match component {
-                                            // TODO: Use object_id generator
-                                            // let id = sensor.unique_id.unwrap_or(format!(
-                                            //     "{}_{}",
-                                            //     core_config.ubihome.name, sensor.name
-                                            // ));
-                                            UbiComponent::Switch(switch) => {
-                                                let topic = format!(
-                                                    "{}/{}/set",
-                                                    base_topic_clone.clone(),
-                                                    switch.id.clone()
-                                                );
-                                                topics.push(topic.clone());
-
-                                                mqtt_components.insert(
-                                                    switch.id.clone(),
-                                                    HAMqttComponent::Switch(HAMqttSwitch {
-                                                        platform: "switch".to_string(),
-                                                        unique_id: switch.id.clone(),
-                                                        command_topic: topic,
-                                                        state_topic: format!(
-                                                            "{}/{}",
-                                                            base_topic_clone.clone(),
-                                                            switch.id.clone()
-                                                        ),
-                                                        name: switch.name.clone(),
-                                                        icon: switch.icon.clone(),
-                                                        object_id: switch.id.clone(),
-                                                    }),
-                                                );
-                                            }
-                                            UbiComponent::Button(button) => {
-                                                let topic = format!(
-                                                    "{}/{}",
-                                                    base_topic_clone.clone(),
-                                                    button.id.clone()
-                                                );
-                                                topics.push(topic.clone());
-                                                mqtt_components.insert(
-                                                    button.id.clone(),
-                                                    HAMqttComponent::Button(HAMqttButton {
-                                                        platform: "button".to_string(),
-                                                        unique_id: button.id.clone(),
-                                                        command_topic: topic,
-                                                        name: button.name.clone(),
-                                                        icon: button.icon.clone(),
-                                                        object_id: button.id.clone(),
-                                                    }),
-                                                );
-                                            }
-                                            UbiComponent::Sensor(sensor) => {
-                                                mqtt_components.insert(
-                                                    sensor.id.clone(),
-                                                    HAMqttComponent::Sensor(HAMqttSensor {
-                                                        platform: "sensor".to_string(),
-                                                        icon: sensor.icon.clone(),
-                                                        unique_id: sensor.id.clone(),
-                                                        device_class: sensor
-                                                            .device_class
-                                                            .clone()
-                                                            .unwrap_or("".to_string()),
-                                                        unit_of_measurement: sensor
-                                                            .unit_of_measurement
-                                                            .clone()
-                                                            .unwrap_or("".to_string()),
-                                                        name: sensor.name.clone(),
-                                                        state_topic: format!(
-                                                            "{}/{}",
-                                                            base_topic_clone.clone(),
-                                                            sensor.id.clone()
-                                                        ),
-                                                        object_id: sensor.id.clone(),
-                                                    }),
-                                                );
-                                            }
-                                            UbiComponent::BinarySensor(sensor) => {
-                                                mqtt_components.insert(
-                                                    sensor.id.clone(),
-                                                    HAMqttComponent::BinarySensor(
-                                                        HAMqttBinarySensor {
-                                                            platform: "binary_sensor".to_string(),
-                                                            icon: sensor.icon.clone(),
-                                                            unique_id: sensor.id.clone(),
-                                                            device_class: sensor
-                                                                .device_class
-                                                                .clone()
-                                                                .unwrap_or("".to_string()),
-                                                            name: sensor.name.clone(),
-                                                            state_topic: format!(
-                                                                "{}/{}",
-                                                                base_topic_clone.clone(),
-                                                                sensor.id.clone()
-                                                            ),
-                                                            object_id: sensor.id.clone(),
-                                                        },
-                                                    ),
-                                                );
-                                            }
-                                            UbiComponent::Light(_light) => {
-                                                // TODO: Add MQTT light support if needed
-                                                // For now, just skip light components for MQTT
-                                            }
-                                            UbiComponent::Number(number) => {
-                                                let state_topic = format!(
-                                                    "{}/{}",
-                                                    base_topic_clone.clone(),
-                                                    number.id.clone()
-                                                );
-                                                let command_topic = format!(
-                                                    "{}/{}/set",
-                                                    base_topic_clone.clone(),
-                                                    number.id.clone()
-                                                );
-                                                topics.push(command_topic.clone());
-
-                                                mqtt_components.insert(
-                                                    number.id.clone(),
-                                                    HAMqttComponent::Number(HAMqttNumber {
-                                                        platform: "number".to_string(),
-                                                        unique_id: number.id.clone(),
-                                                        command_topic,
-                                                        state_topic,
-                                                        name: number.name.clone(),
-                                                        icon: number.icon.clone(),
-                                                        object_id: number.id.clone(),
-                                                        min: number.min_value,
-                                                        max: number.max_value,
-                                                        step: number.step,
-                                                        unit_of_measurement: number
-                                                            .unit_of_measurement
-                                                            .clone()
-                                                            .filter(|s| !s.is_empty()),
-                                                    }),
-                                                );
-                                            }
-                                            UbiComponent::TextSensor(_text_sensor) => {
-                                                // TODO: Add MQTT text sensor support if needed
-                                            }
-                                        }
-                                    }
-                                    {
-                                        let mut all_mqtt_components =
-                                            all_mqtt_components_clone.write().await;
-                                        all_mqtt_components.extend(mqtt_components.clone());
-                                        debug!("MQTT Components: {:?}", mqtt_components.keys());
-                                    }
-
-                                    let ip = get_ip_address().unwrap();
-                                    let mac = get_network_mac_address(ip).unwrap();
-                                    let device = HAMqttDevice {
-                                        identifiers: vec![config.ubihome.name.clone()],
-                                        manufacturer: format!(
-                                            "{} {} {}",
-                                            whoami::platform(),
-                                            whoami::distro(),
-                                            whoami::arch()
-                                        ),
-                                        name: config.ubihome.name.clone(),
-                                        model: whoami::devicename(),
-                                        connections: vec![HAMqttConnection {
-                                            r#type: "mac".to_string(),
-                                            value: mac,
-                                        }],
-                                    };
-
-                                    let origin = HAMqttOrigin {
-                                        name: "ubihome".to_string(),
-                                        sw: "0.1".to_string(),
-                                        url: "https://test.com".to_string(),
-                                    };
-
-                                    let discovery_message = HAMqttDiscoveryMessage {
-                                        device,
-                                        origin,
-                                        components: mqtt_components.clone(),
-                                    };
-                                    let discovery_payload =
-                                        serde_json::to_string(&discovery_message).unwrap();
-
-                                    debug!(
-                                        "Publishing discovery message to topic: {}",
-                                        discovery_topic
-                                    );
-                                    debug!("Discovery payload: {}", discovery_payload);
-                                    client
-                                        .publish(
-                                            &discovery_topic,
-                                            QoS::AtLeastOnce,
-                                            false,
-                                            discovery_payload,
-                                        )
-                                        .await
-                                        .unwrap();
-
-                                    debug!("Discovery message published successfully");
-
-                                    // Subscribe to the discovery topic
-                                    for topic in topics {
-                                        debug!("Subscribing to topic: {}", topic);
-                                        client.subscribe(&topic, QoS::AtLeastOnce).await.unwrap();
-                                    }
-                                }
                                 PublishedMessage::SensorValueChanged { key, value } => {
                                     debug!("Sensor value published: {} = {}", key, value);
                                     // Handle sensor value change

--- a/components/online/src/lib.rs
+++ b/components/online/src/lib.rs
@@ -11,9 +11,9 @@ use tokio::{
 };
 use ubihome_core::constants::{is_id_string_option, is_readable_string};
 use ubihome_core::internal::sensors::{UbiBinarySensor, UbiComponent};
+use ubihome_core::state::StateStore;
 use ubihome_core::template_binary_sensor;
 use ubihome_core::with_base_entity_properties;
-use ubihome_core::state::StateStore;
 use ubihome_core::{config_template, ChangedMessage, Module, NoConfig, PublishedMessage};
 
 #[derive(Clone, Default, Deserialize, Debug, PartialEq, Validate)]

--- a/components/online/src/lib.rs
+++ b/components/online/src/lib.rs
@@ -13,6 +13,7 @@ use ubihome_core::constants::{is_id_string_option, is_readable_string};
 use ubihome_core::internal::sensors::{UbiBinarySensor, UbiComponent};
 use ubihome_core::template_binary_sensor;
 use ubihome_core::with_base_entity_properties;
+use ubihome_core::state::StateStore;
 use ubihome_core::{config_template, ChangedMessage, Module, NoConfig, PublishedMessage};
 
 #[derive(Clone, Default, Deserialize, Debug, PartialEq, Validate)]
@@ -208,6 +209,7 @@ impl Module for UbiHomePlatform {
         &self,
         sender: Sender<ChangedMessage>,
         _receiver: Receiver<PublishedMessage>,
+        _state: StateStore,
     ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static>>
     {
         let binary_sensors = self.binary_sensors.clone();

--- a/components/power_utils/src/lib.rs
+++ b/components/power_utils/src/lib.rs
@@ -6,6 +6,7 @@ use tokio::sync::broadcast::{Receiver, Sender};
 use ubihome_core::constants::is_id_string_option;
 use ubihome_core::constants::is_readable_string;
 use ubihome_core::internal::sensors::UbiComponent;
+use ubihome_core::state::StateStore;
 use ubihome_core::template_button;
 use ubihome_core::with_base_entity_properties;
 use ubihome_core::{
@@ -124,6 +125,7 @@ impl Module for UbiHomePlatform {
         &self,
         _: Sender<ChangedMessage>,
         mut receiver: Receiver<PublishedMessage>,
+        _state: StateStore,
     ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static>>
     {
         let buttons = self.buttons.clone();

--- a/components/sendspin/src/lib.rs
+++ b/components/sendspin/src/lib.rs
@@ -18,6 +18,7 @@ use tokio::sync::broadcast::Receiver;
 use tokio::sync::broadcast::Sender;
 use ubihome_core::internal::sensors::UbiComponent;
 use ubihome_core::NoConfig;
+use ubihome_core::state::StateStore;
 use ubihome_core::{config_template, ChangedMessage, Module, PublishedMessage};
 
 /// Type alias for the clock sync reference
@@ -162,6 +163,7 @@ impl Module for UbiHomePlatform {
         &self,
         _sender: Sender<ChangedMessage>,
         mut _receiver: Receiver<PublishedMessage>,
+        _state: StateStore,
     ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static>>
     {
         let name = self

--- a/components/sendspin/src/lib.rs
+++ b/components/sendspin/src/lib.rs
@@ -17,8 +17,8 @@ use std::{future::Future, pin::Pin, str};
 use tokio::sync::broadcast::Receiver;
 use tokio::sync::broadcast::Sender;
 use ubihome_core::internal::sensors::UbiComponent;
-use ubihome_core::NoConfig;
 use ubihome_core::state::StateStore;
+use ubihome_core::NoConfig;
 use ubihome_core::{config_template, ChangedMessage, Module, PublishedMessage};
 
 /// Type alias for the clock sync reference

--- a/components/shell/src/lib.rs
+++ b/components/shell/src/lib.rs
@@ -952,7 +952,7 @@ number:
     command_set: "echo {{ value }}"
 "#;
 
-        let module = UbiHomePlatform::new(&config.to_string(), "config.yml");
+        let module = UbiHomePlatform::new(config, "config.yml");
         assert!(
             module.is_ok(),
             "Shell module should parse number config successfully"
@@ -999,7 +999,7 @@ number:
     name: "Volume"
 "#;
 
-        let module = UbiHomePlatform::new(&config.to_string(), "config.yml");
+        let module = UbiHomePlatform::new(config, "config.yml");
         assert!(
             module.is_ok(),
             "Shell module should parse minimal number config successfully"
@@ -1044,7 +1044,7 @@ text_sensor:
     command: "whoami"
 "#;
 
-        let module = UbiHomePlatform::new(&config.to_string(), "config.yml");
+        let module = UbiHomePlatform::new(config, "config.yml");
         assert!(
             module.is_ok(),
             "Shell module should parse text_sensor config successfully"
@@ -1083,7 +1083,7 @@ text_sensor:
     command: "hostname"
 "#;
 
-        let module = UbiHomePlatform::new(&config.to_string(), "config.yml");
+        let module = UbiHomePlatform::new(config, "config.yml");
         assert!(
             module.is_ok(),
             "Shell module should parse minimal text_sensor config successfully"

--- a/components/shell/src/lib.rs
+++ b/components/shell/src/lib.rs
@@ -16,6 +16,7 @@ use ubihome_core::template_text_sensor;
 use ubihome_core::{
     config_template,
     internal::sensors::{UbiBinarySensor, UbiButton, UbiSensor},
+    state::StateStore,
     ChangedMessage, Module, PublishedMessage,
 };
 
@@ -313,6 +314,7 @@ impl Module for UbiHomePlatform {
         &self,
         sender: Sender<ChangedMessage>,
         mut receiver: Receiver<PublishedMessage>,
+        _state: StateStore,
     ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static>>
     {
         let config = self.config.clone();
@@ -950,7 +952,7 @@ number:
     command_set: "echo {{ value }}"
 "#;
 
-        let module = UbiHomePlatform::new(&config.to_string());
+        let module = UbiHomePlatform::new(&config.to_string(), "config.yml");
         assert!(
             module.is_ok(),
             "Shell module should parse number config successfully"
@@ -997,7 +999,7 @@ number:
     name: "Volume"
 "#;
 
-        let module = UbiHomePlatform::new(&config.to_string());
+        let module = UbiHomePlatform::new(&config.to_string(), "config.yml");
         assert!(
             module.is_ok(),
             "Shell module should parse minimal number config successfully"
@@ -1042,7 +1044,7 @@ text_sensor:
     command: "whoami"
 "#;
 
-        let module = UbiHomePlatform::new(&config.to_string());
+        let module = UbiHomePlatform::new(&config.to_string(), "config.yml");
         assert!(
             module.is_ok(),
             "Shell module should parse text_sensor config successfully"
@@ -1081,7 +1083,7 @@ text_sensor:
     command: "hostname"
 "#;
 
-        let module = UbiHomePlatform::new(&config.to_string());
+        let module = UbiHomePlatform::new(&config.to_string(), "config.yml");
         assert!(
             module.is_ok(),
             "Shell module should parse minimal text_sensor config successfully"

--- a/components/web_server/src/lib.rs
+++ b/components/web_server/src/lib.rs
@@ -26,8 +26,8 @@ use serde::Deserializer;
 use std::collections::HashMap;
 use std::{future::Future, pin::Pin, str};
 use tokio::sync::broadcast::{Receiver, Sender};
-use ubihome_core::NoConfig;
 use ubihome_core::state::StateStore;
+use ubihome_core::NoConfig;
 use ubihome_core::{config_template, ChangedMessage, Module, PublishedMessage};
 
 #[derive(Clone, Deserialize, Debug, Validate)]

--- a/components/web_server/src/lib.rs
+++ b/components/web_server/src/lib.rs
@@ -27,6 +27,7 @@ use std::collections::HashMap;
 use std::{future::Future, pin::Pin, str};
 use tokio::sync::broadcast::{Receiver, Sender};
 use ubihome_core::NoConfig;
+use ubihome_core::state::StateStore;
 use ubihome_core::{config_template, ChangedMessage, Module, PublishedMessage};
 
 #[derive(Clone, Deserialize, Debug, Validate)]
@@ -189,6 +190,7 @@ impl Module for UbiHomePlatform {
         &self,
         _sender: Sender<ChangedMessage>,
         receiver: Receiver<PublishedMessage>,
+        _state: StateStore,
     ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static>>
     {
         let config = self.config.clone();

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -6,6 +6,7 @@ use flexi_logger::{detailed_format, Age, Cleanup, Criterion, Duplicate, FileSpec
 use ubihome_core::configuration::binary_sensor::{Action, ActionType, FilterType};
 use ubihome_core::configuration::sensor::SensorFilterType;
 use ubihome_core::internal::sensors::UbiComponent;
+use ubihome_core::state::{EntityState, StateStoreWriter};
 use ubihome_core::{ChangedMessage, PublishedMessage};
 
 use futures_signals::signal::{Mutable, SignalExt};
@@ -195,6 +196,11 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
         return Ok(());
     }
 
+    // The global entity state cache: only this function (the main application)
+    // ever holds a `StateStoreWriter`. Platform modules only ever receive the
+    // read-only `StateStore` handed out below via `run_platforms`.
+    let (state_writer, state_store) = StateStoreWriter::new(initialized_platforms.clone());
+
     // Spawn the root task
     let rt = Runtime::new().unwrap();
     rt.block_on(async {
@@ -221,6 +227,7 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
                     let mutable: Mutable<Option<Option<f32>>> = Mutable::new(Option::None);
                     signal_map_sensor.insert(sensor.id.clone(), mutable.clone());
                     let internal_tx_clone = internal_tx.clone();
+                    let state_writer_clone = state_writer.clone();
 
                     let mutable_clone = mutable.clone();
                     supervised_tasks.spawn(async move {
@@ -255,6 +262,7 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
 
                                 let key = sensor.id.clone();
                                 if let Some(value) = value.and_then(|v| v) {
+                                    state_writer_clone.set(key.clone(), EntityState::Sensor(value));
                                     let pcmd = PublishedMessage::SensorValueChanged { key, value };
                                     debug!("Publishing command from signal: {:?}", pcmd);
 
@@ -282,6 +290,7 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
                     let mutable: Mutable<Option<Option<bool>>> = Mutable::new(Option::None);
                     signal_map_binary_sensor.insert(binary_sensor.id.clone(), mutable.clone());
                     let internal_tx_clone = internal_tx.clone();
+                    let state_writer_clone = state_writer.clone();
 
                     let mutable_clone = mutable.clone();
                     supervised_tasks.spawn(async move {
@@ -352,6 +361,7 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
                             .for_each(move |value| {
                                 let action_tx = internal_tx_clone.clone();
                                 let signal_tx_clone = internal_tx_clone.clone();
+                                let state_writer_for_call = state_writer_clone.clone();
 
                                 let key = binary_sensor.id.clone();
                                 let on_press = binary_sensor.on_press.clone();
@@ -366,6 +376,8 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
                                             run_actions(on_release.then, &action_tx).await;
                                         }
 
+                                        state_writer_for_call
+                                            .set(key.clone(), EntityState::BinarySensor(value));
                                         let pcmd = PublishedMessage::BinarySensorValueChanged {
                                             key,
                                             value,
@@ -393,6 +405,7 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
         }
 
         let internal_tx_clone = internal_tx.clone();
+        let state_writer_clone = state_writer.clone();
         supervised_tasks.spawn({
             async move {
                 while let Ok(cmd) = internal_rx.recv().await {
@@ -464,6 +477,38 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
                         }
                     };
                     if let Some(pcmd) = publish_cmd {
+                        match &pcmd {
+                            PublishedMessage::SwitchStateChange { key, state } => {
+                                state_writer_clone.set(key.clone(), EntityState::Switch(*state));
+                            }
+                            PublishedMessage::LightStateChange {
+                                key,
+                                state,
+                                brightness,
+                                red,
+                                green,
+                                blue,
+                            } => {
+                                state_writer_clone.set(
+                                    key.clone(),
+                                    EntityState::Light {
+                                        state: *state,
+                                        brightness: *brightness,
+                                        red: *red,
+                                        green: *green,
+                                        blue: *blue,
+                                    },
+                                );
+                            }
+                            PublishedMessage::NumberValueChanged { key, value } => {
+                                state_writer_clone.set(key.clone(), EntityState::Number(*value));
+                            }
+                            PublishedMessage::TextSensorValueChanged { key, value } => {
+                                state_writer_clone
+                                    .set(key.clone(), EntityState::TextSensor(value.clone()));
+                            }
+                            _ => {}
+                        }
                         debug!("Publishing command: {:?}", pcmd);
                         internal_tx_clone.send(pcmd).unwrap();
                     }
@@ -476,29 +521,10 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
             configured_platforms,
             modules_tx.clone(),
             modules_rx,
+            state_store,
         );
 
         println!("Platforms: {:?}", initialized_platforms);
-        internal_tx
-            .send(PublishedMessage::Components {
-                components: initialized_platforms
-                    .iter()
-                    .map(|c| match c {
-                        UbiComponent::Switch(switch) => UbiComponent::Switch(switch.clone()),
-                        UbiComponent::Button(button) => UbiComponent::Button(button.clone()),
-                        UbiComponent::Sensor(sensor) => UbiComponent::Sensor(sensor.clone()),
-                        UbiComponent::BinarySensor(binary_sensor) => {
-                            UbiComponent::BinarySensor(binary_sensor.clone())
-                        }
-                        UbiComponent::Light(light) => UbiComponent::Light(light.clone()),
-                        UbiComponent::Number(number) => UbiComponent::Number(number.clone()),
-                        UbiComponent::TextSensor(text_sensor) => {
-                            UbiComponent::TextSensor(text_sensor.clone())
-                        }
-                    })
-                    .collect(),
-            })
-            .unwrap();
 
         let ctrl_c = async {
             signal::ctrl_c()

--- a/src/components.rs
+++ b/src/components.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 use std::collections::BTreeSet;
 use tokio::sync::broadcast::{Receiver, Sender};
 use ubihome_core::internal::sensors::UbiComponent;
+use ubihome_core::state::StateStore;
 use ubihome_core::Module;
 use ubihome_core::{ChangedMessage, PublishedMessage};
 
@@ -88,17 +89,19 @@ pub(crate) fn run_platforms(
     modules: Vec<Box<dyn Module>>,
     sender: Sender<ChangedMessage>,
     receiver: Receiver<PublishedMessage>,
+    state: StateStore,
 ) {
     for module in modules {
         let tx = sender.clone();
         let rx = receiver.resubscribe();
+        let state = state.clone();
         tasks.spawn(async move {
             // A module returning Ok(()) is a normal, intentional exit and stays
             // silent. An Err is a real failure: unwrap panics, which is reported to
             // Sentry by the panic integration. Tasks are collected in a JoinSet so
             // the caller observes the panic (instead of it being swallowed by this
             // task) and shuts the application down.
-            module.run(tx, rx).await.unwrap();
+            module.run(tx, rx, state).await.unwrap();
         });
     }
 }
@@ -106,6 +109,7 @@ pub(crate) fn run_platforms(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ubihome_core::state::StateStoreWriter;
     use ubihome_core::ModuleRunFuture;
 
     #[test]
@@ -134,6 +138,7 @@ mod tests {
             &self,
             _sender: Sender<ChangedMessage>,
             _receiver: Receiver<PublishedMessage>,
+            _state: StateStore,
         ) -> ModuleRunFuture {
             let should_err = self.should_err;
             Box::pin(async move {
@@ -151,7 +156,8 @@ mod tests {
         let (_published_tx, published_rx) = tokio::sync::broadcast::channel::<PublishedMessage>(16);
         let mut tasks = tokio::task::JoinSet::new();
         let modules: Vec<Box<dyn Module>> = vec![Box::new(MockModule { should_err })];
-        run_platforms(&mut tasks, modules, changed_tx, published_rx);
+        let (_state_writer, state) = StateStoreWriter::new(Vec::new());
+        run_platforms(&mut tasks, modules, changed_tx, published_rx, state);
         tasks
     }
 

--- a/tests/e2e/home_assistant_native_api_e2e_test.py
+++ b/tests/e2e/home_assistant_native_api_e2e_test.py
@@ -200,7 +200,7 @@ async def test_button_and_switch_actions_are_executed(ha_page: Page, io_mock_fac
         await ha_page.get_by_role("button", name="Press").click()
         ubihome.button_sensor_mock.wait_for_mock_state("button")
 
-        await ha_page.get_by_role("button", name=f"Toggle {ubihome.device_name} Switch it on").click()
+        await ha_page.get_by_role("switch", name=f"Toggle {ubihome.device_name} Switch it on").click()
         ubihome.switch_mock.wait_for_mock_state("true")
 
 

--- a/tests/internal/filter_test.py
+++ b/tests/internal/filter_test.py
@@ -29,7 +29,8 @@ sensor:
     filters:
       - round: 2
 """
-    io_mock.set_value("0.1111")
+    # Round down: 1.123345 -> 1.12
+    io_mock.set_value("1.123345")
 
     async with UbiHome("run", config=DEVICE_INFO_CONFIG, wait_for_api=True) as ubihome:
         api = aioesphomeapi.APIClient("127.0.0.1", ubihome.port, "")
@@ -46,9 +47,6 @@ sensor:
         mock = Mock()
         api.subscribe_states(mock)
 
-        # Round down: 1.123345 -> 1.12
-        io_mock.set_value("1.123345")
-
         while not mock.called:
             await sleep(0.1)
 
@@ -56,20 +54,18 @@ sensor:
         assert state.state == pytest.approx(1.12)
 
         # Round up: 1.126 -> 1.13
-        mock.reset_mock()
         io_mock.set_value("1.126")
 
-        while not mock.called:
+        while not (mock.called and mock.call_args.args[0].state == pytest.approx(1.13)):
             await sleep(0.1)
 
         state = mock.call_args.args[0]
         assert state.state == pytest.approx(1.13)
 
         # Edge case: 1.125 rounds to 1.12 (round-half-to-even / banker's rounding in f32)
-        mock.reset_mock()
         io_mock.set_value("1.125")
 
-        while not mock.called:
+        while not (mock.called and mock.call_args.args[0].state == pytest.approx(1.12)):
             await sleep(0.1)
 
         state = mock.call_args.args[0]
@@ -97,7 +93,8 @@ sensor:
     filters:
       - round: 3
 """
-    io_mock.set_value("0.1111")
+    # Round down: 1.12341 -> 1.123
+    io_mock.set_value("1.12341")
 
     async with UbiHome("run", config=DEVICE_INFO_CONFIG, wait_for_api=True) as ubihome:
         api = aioesphomeapi.APIClient("127.0.0.1", ubihome.port, "")
@@ -109,9 +106,6 @@ sensor:
         mock = Mock()
         api.subscribe_states(mock)
 
-        # Round down: 1.12341 -> 1.123
-        io_mock.set_value("1.12341")
-
         while not mock.called:
             await sleep(0.1)
 
@@ -119,10 +113,9 @@ sensor:
         assert state.state == pytest.approx(1.123)
 
         # Round up: 1.12361 -> 1.124
-        mock.reset_mock()
         io_mock.set_value("1.12361")
 
-        while not mock.called:
+        while not (mock.called and mock.call_args.args[0].state == pytest.approx(1.124)):
             await sleep(0.1)
 
         state = mock.call_args.args[0]

--- a/tests/platforms/api/binary_sensor_test.py
+++ b/tests/platforms/api/binary_sensor_test.py
@@ -28,7 +28,7 @@ binary_sensor:
     name: {sensor_name}
     command: "cat {io_mock.file}"
 """
-    io_mock.set_value("false")
+    io_mock.set_value("true")
 
     async with UbiHome("run", config=DEVICE_INFO_CONFIG, wait_for_api=True) as ubihome:
         api = aioesphomeapi.APIClient("127.0.0.1", ubihome.port, "")
@@ -46,9 +46,6 @@ binary_sensor:
         # Subscribe to the state changes
         api.subscribe_states(mock)
 
-        io_mock.set_value("true")
-
-        # Wait for the state change
         while not mock.called:
             await sleep(0.1)
 
@@ -57,9 +54,7 @@ binary_sensor:
 
         io_mock.set_value("false")
 
-        mock.reset_mock()
-        # Wait for the state change
-        while not mock.called:
+        while not (mock.called and mock.call_args.args[0].state is False):
             await sleep(0.1)
 
         state = mock.call_args.args[0]

--- a/tests/platforms/api/light_test.py
+++ b/tests/platforms/api/light_test.py
@@ -10,7 +10,7 @@ from utils import SHELL_TYPE, UbiHome
 async def test_run(io_mock: IOMock):
     light_id = "my_light"
     light_name = "Test Light"
-    io_mock.set_value("false")
+    io_mock.set_value("true")
     DEVICE_INFO_CONFIG = f"""
 ubihome:
   name: test_device
@@ -47,9 +47,6 @@ light:
         # Subscribe to the state changes
         api.subscribe_states(mock)
 
-        io_mock.set_value("true")
-
-        # Wait for the state change
         while not mock.called:
             await sleep(0.1)
 

--- a/tests/platforms/api/sensor_test.py
+++ b/tests/platforms/api/sensor_test.py
@@ -27,7 +27,7 @@ sensor:
     name: {sensor_name}
     command: "cat {io_mock.file}"
 """
-    io_mock.set_value("0.1")
+    io_mock.set_value("0.2")
 
     async with UbiHome("run", config=DEVICE_INFO_CONFIG, wait_for_api=True) as ubihome:
         api = aioesphomeapi.APIClient("127.0.0.1", ubihome.port, "")
@@ -46,9 +46,6 @@ sensor:
         # Subscribe to the state changes
         api.subscribe_states(mock)
 
-        io_mock.set_value("0.2")
-
-        # Wait for the state change
         while not mock.called:
             await sleep(0.1)
 


### PR DESCRIPTION
First (internal) messages always got lost. This should make sure that on connect the state of an entity is directly available. 