### PR TITLE
feat(core): add on_startup trigger

### DIFF
--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -18,6 +18,7 @@ use serde::Deserialize;
 use std::{collections::HashMap, future::Future, pin::Pin};
 use tokio::sync::broadcast::{Receiver, Sender};
 
+use crate::configuration::binary_sensor::Trigger;
 use crate::constants::{is_readable_string, is_readable_string_option};
 use crate::state::StateStore;
 
@@ -186,6 +187,9 @@ pub struct UbiHome {
     pub friendly_name: Option<String>,
     #[garde(custom(is_readable_string_option), length(min = 3, max = 100))]
     pub area: Option<String>,
+    /// Actions to run once, when UbiHome starts up.
+    #[garde(dive)]
+    pub on_startup: Option<Trigger>,
 }
 
 #[macro_export]

--- a/documentation/src/content/docs/features/components/actions.md
+++ b/documentation/src/content/docs/features/components/actions.md
@@ -9,6 +9,16 @@ Currently triggers are available on the [Binary Sensor](/features/entities/binar
 - `on_press` — runs when the state changes to `true`.
 - `on_release` — runs when the state changes to `false`.
 
+There is also a global `on_startup` trigger, configured under `ubihome:`, that runs once when UbiHome starts:
+
+```yaml
+ubihome:
+  name: 'Raspberry Pi behind the TV'
+  on_startup:
+    then:
+      - switch.turn_on: status_led
+```
+
 Each trigger takes a `then` block listing the actions to run in order:
 
 ```yaml

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -524,6 +524,15 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
             state_store,
         );
 
+        // Fire the `ubihome.on_startup` trigger once, now that every platform
+        // module has resubscribed and is listening for published commands.
+        if let Some(on_startup) = config.ubihome.on_startup.clone() {
+            let internal_tx_clone = internal_tx.clone();
+            supervised_tasks.spawn(async move {
+                run_actions(on_startup.then, &internal_tx_clone).await;
+            });
+        }
+
         println!("Platforms: {:?}", initialized_platforms);
 
         let ctrl_c = async {

--- a/tests/internal/trigger_action_test.py
+++ b/tests/internal/trigger_action_test.py
@@ -86,6 +86,37 @@ binary_sensor:
         button_mock.wait_for_mock_state("pressed")
 
 
+async def test_on_startup_trigger(io_mock_factory: IOMockFactory):
+    """
+    Test that the `ubihome.on_startup` trigger runs its actions once when
+    UbiHome starts up.
+    """
+
+    switch_mock = io_mock_factory.create_mock()
+
+    DEVICE_INFO_CONFIG = f"""
+ubihome:
+  name: test_device
+  on_startup:
+    then:
+      - switch.turn_on: "test_switch"
+
+shell:
+
+switch:
+  - platform: shell
+    name: "Test Switch"
+    id: test_switch
+    command_on: "echo true > {switch_mock}"
+    command_off: "echo false > {switch_mock}"
+    command_state: "cat {switch_mock} || echo false"
+"""
+    switch_mock.set_value("false")
+
+    async with UbiHome("run", config=DEVICE_INFO_CONFIG):
+        switch_mock.wait_for_mock_state("true")
+
+
 async def test_binary_sensor_delay_action(io_mock_factory: IOMockFactory):
     """
     Test that the `delay` action pauses an action list without aborting it: the


### PR DESCRIPTION
## Summary
- Add a global `ubihome.on_startup` trigger (similar to ESPHome's [`esphome.on_boot`](https://esphome.io/components/esphome/#on_boot)) that runs a `then:` action list once when UbiHome starts.
- Reuses the existing `Trigger`/`Action`/`ActionType` machinery already used by binary sensor `on_press`/`on_release` triggers — no new message types needed.
- Actions run after all platform modules have subscribed to the internal command channel, so `switch.turn_on`, `button.press`, etc. reliably reach their target modules.

```yaml
ubihome:
  name: 'Raspberry Pi behind the TV'
  on_startup:
    then:
      - switch.turn_on: status_led
```

## Test plan
- [x] `cargo check` / `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] Added `tests/internal/trigger_action_test.py::test_on_startup_trigger` (e2e, passes)
- [x] Documented in `documentation/src/content/docs/features/components/actions.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)