### PR TITLE
fix(tests): avoid random port collisions causing CI AddrInUse flake

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import os
 import platform
-import random
 import re
 import signal
 import socket
@@ -18,6 +17,13 @@ def represent_none(self, _):
 
 
 yaml.add_representer(type(None), represent_none)
+
+
+def _get_free_port() -> int:
+    """Ask the OS for an unused TCP port instead of guessing one."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
 
 
 @dataclass
@@ -181,7 +187,7 @@ class UbiHome:
             if "api" in config_yaml:
                 if config_yaml["api"] is None:
                     config_yaml["api"] = {}
-                self.port = random.randint(1024, 65535)
+                self.port = _get_free_port()
                 config_yaml["api"]["port"] = self.port
 
             self.config = yaml.dump(config_yaml)


### PR DESCRIPTION
## Summary
- CI intermittently panicked with `Result::unwrap() on an Err value: Os { code: 98, kind: AddrInUse }` (`components/api/src/lib.rs`'s `socket.bind(addr).unwrap()`).
- Root cause: `tests/utils.py`'s `UbiHome` test harness picked the `api:` port via `random.randint(1024, 65535)` without ever checking it was free. That range fully overlaps the Linux ephemeral port pool used concurrently in CI by Docker (testcontainers for Home Assistant/Mosquitto), Playwright, and other client sockets, so collisions were plausible under CI load even though pytest itself runs sequentially (no xdist).
- Fix: bind to port `0` and read back the OS-assigned free port instead, matching the pattern already used in `tests/platforms/online/online_test.py`'s `_start_tcp_target`/`_start_dns_target` helpers. This is scoped to the Python test harness only — the Rust bind path is unchanged since it's correct to fail loudly on a real user-supplied port conflict.

## Test plan
- [x] `cargo build`, ran `tests/platforms/api/binary_sensor_test.py` locally against the built binary — passes, confirms the OS-assigned port path works end to end.
- [ ] Full suite validated in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)