### PR TITLE
feat: add logger.log action

### DIFF
--- a/components/core/src/configuration/automation.rs
+++ b/components/core/src/configuration/automation.rs
@@ -36,6 +36,10 @@ pub enum ActionType {
     /// next action.
     #[serde(rename = "delay", deserialize_with = "deserialize_duration")]
     Delay(#[garde(skip)] Duration),
+
+    /// Logs `value` to the console at info level.
+    #[serde(rename = "logger.log")]
+    LoggerLog(#[garde(skip)] GlobalValue),
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Validate)]

--- a/documentation/src/content/docs/features/components/actions.md
+++ b/documentation/src/content/docs/features/components/actions.md
@@ -55,6 +55,7 @@ See [Filters](/features/components/filters/) for the available debounce filters.
 | `button.press`    | button `id` | Presses the referenced [button](/features/entities/button/), running its platform action. |
 | `globals.set`     | `id`, `value` | Sets a [global](/features/components/globals/) variable to `value`. |
 | `delay`           | duration    | Pauses the action list for the given duration (e.g. `2s`, `500ms`) before running the next action. |
+| `logger.log`      | value       | Logs the given value to the console at info level. |
 
 For entity actions the argument is the `id` of the target entity, so make sure the switch or button you reference has an `id` set.
 
@@ -72,3 +73,10 @@ binary_sensor:
 
 `globals.set` takes `id`/`value` arguments instead of a single id; see
 [Globals](/features/components/globals/) for the `value` syntax.
+
+`logger.log` takes a plain YAML scalar (string, boolean, or number), the same
+way `globals.set`'s `value` does:
+
+```yaml
+- logger.log: 'Motion detected'
+```

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -111,6 +111,9 @@ pub async fn run_actions(actions: Vec<Action>, tx: &Sender<PublishedMessage>, gl
             ActionType::Delay(duration) => {
                 tokio::time::sleep(*duration).await;
             }
+            ActionType::LoggerLog(value) => {
+                log::info!("{value}");
+            }
         }
     }
 }

--- a/tests/internal/trigger_action_test.py
+++ b/tests/internal/trigger_action_test.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from mock_file import IOMockFactory
 from utils import UbiHome
 
@@ -170,3 +172,38 @@ binary_sensor:
         # Action after the delay presses the button, proving the delay does not
         # abort the remaining actions in the list.
         button_mock.wait_for_mock_state("pressed")
+
+
+async def test_binary_sensor_logger_log_action(io_mock_factory: IOMockFactory):
+    """
+    Test that the `logger.log` action logs the given value to the console.
+    """
+
+    sensor_mock = io_mock_factory.create_mock()
+
+    DEVICE_INFO_CONFIG = f"""
+ubihome:
+  name: test_device
+
+shell:
+
+binary_sensor:
+  - platform: shell
+    name: "Test Binary Sensor"
+    update_interval: 2s
+    command: |-
+      cat {sensor_mock}
+    on_press:
+      then:
+        - logger.log: "Motion detected"
+"""
+    sensor_mock.set_value("false")
+
+    async with UbiHome("run", config=DEVICE_INFO_CONFIG) as ubihome:
+        sensor_mock.set_value("true")
+
+        async def wait_for_log():
+            while "Motion detected" not in (ubihome.stdout or ""):
+                await asyncio.sleep(0.1)
+
+        await asyncio.wait_for(wait_for_log(), timeout=5)


### PR DESCRIPTION
## Summary
- Add a `logger.log` automation action that logs its argument (a plain YAML scalar: string, bool, int, or float) to the console at info level, alongside the existing `switch.turn_on`/`switch.turn_off`/`button.press`/`globals.set`/`delay` actions.
- Document the new action in the Triggers and Actions page.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build`
- [x] `uv run pytest internal/trigger_action_test.py -k "not test_binary_sensor_triggers"` (new `test_binary_sensor_logger_log_action` passes; `test_binary_sensor_triggers` fails identically on unmodified `main`, unrelated pre-existing Windows flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)