### PR TITLE
feat(template): add sensor platform

### DIFF
--- a/documentation/src/content/docs/features/platforms/template.md
+++ b/documentation/src/content/docs/features/platforms/template.md
@@ -1,6 +1,6 @@
 ---
 title: 'Template'
-description: 'A switch, button or number that runs automations instead of talking to hardware'
+description: 'A switch, button, number or sensor that runs automations instead of talking to hardware'
 ---
 
 The `template` platform creates entities driven entirely by automations
@@ -160,11 +160,40 @@ number:
 
 Similar to ESPHome: [Template Number](https://esphome.io/components/number/template/)
 
+## Sensor
+
+Sensors are read-only, so - unlike the switch/number above - there is no
+command a client can send. The reported value always comes from a `lambda`
+reading a `float` [global](/features/components/globals/), and updates live
+whenever that global changes.
+
+```yaml
+globals:
+  - id: room_temperature_value
+    type: float
+    initial_value: 21.5
+
+sensor:
+  - platform: template
+    name: 'Room Temperature'
+    id: room_temperature
+    unit_of_measurement: '°C'
+    lambda:
+      globals.get: room_temperature_value
+```
+
+`unit_of_measurement`, `device_class`, `state_class`, `accuracy_decimals` and
+`filters` are the shared [Sensor](/features/entities/sensor/) attributes.
+
+Similar to ESPHome: [Template Sensor](https://esphome.io/components/sensor/template/)
+
 <!-- Backlinks to be displayed  -->
 <div style="display:none" aria-hidden="true">
   <a href="/features/entities/switch/">Switch</a>
   <a href="/features/entities/button/">Button</a>
   <a href="/features/entities/number/">Number</a>
+  <a href="/features/entities/sensor/">Sensor</a>
   <a href="/features/components/actions/">Triggers and Actions</a>
   <a href="/features/components/globals/">Globals</a>
+  <a href="/features/components/filters/">Filters</a>
 </div>

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -25,7 +25,9 @@ use ubihome_core::PublishedMessage;
 pub use globals::{GlobalConfig, Globals};
 pub use template::TemplateConfig;
 
-use template::{TemplateButtonConfig, TemplateNumberConfig, TemplateSwitchConfig};
+use template::{
+    TemplateButtonConfig, TemplateNumberConfig, TemplateSensorConfig, TemplateSwitchConfig,
+};
 
 /// The switch/button/number platform name handled by the builtin template
 /// components.
@@ -40,6 +42,7 @@ pub const BUILTIN_SECTIONS: &[&str] = &["globals"];
 template_mapper!(map_switch, template, TemplateSwitchConfig);
 template_mapper!(map_button, template, TemplateButtonConfig);
 template_mapper!(map_number, template, TemplateNumberConfig);
+template_mapper!(map_sensor, template, TemplateSensorConfig);
 
 #[derive(Debug, Deserialize, Validate)]
 #[garde(allow_unvalidated)]
@@ -52,6 +55,9 @@ struct BuiltinRoot {
 
     #[serde(default, deserialize_with = "map_number")]
     number: Option<HashMap<String, TemplateNumberConfig>>,
+
+    #[serde(default, deserialize_with = "map_sensor")]
+    sensor: Option<HashMap<String, TemplateSensorConfig>>,
 
     #[serde(default)]
     #[garde(dive)]
@@ -76,6 +82,7 @@ pub fn parse(config_string: &str, config_path: &str) -> Result<BuiltinConfig, St
             switches: root.switch.unwrap_or_default().into_values().collect(),
             buttons: root.button.unwrap_or_default().into_values().collect(),
             numbers: root.number.unwrap_or_default().into_values().collect(),
+            sensors: root.sensor.unwrap_or_default().into_values().collect(),
         },
         globals: root.globals,
     })

--- a/src/builtins/template/mod.rs
+++ b/src/builtins/template/mod.rs
@@ -6,19 +6,21 @@
 pub mod button;
 pub mod lambda;
 pub mod number;
+pub mod sensor;
 pub mod switch;
 
 pub use button::TemplateButtonConfig;
 pub use number::TemplateNumberConfig;
+pub use sensor::TemplateSensorConfig;
 pub use switch::TemplateSwitchConfig;
 
 use std::collections::HashMap;
 
 use tokio::sync::broadcast::{Receiver, Sender};
 use tokio::task::JoinSet;
-use ubihome_core::internal::sensors::{UbiButton, UbiComponent, UbiNumber, UbiSwitch};
+use ubihome_core::internal::sensors::{UbiButton, UbiComponent, UbiNumber, UbiSensor, UbiSwitch};
 use ubihome_core::state::{EntityState, StateStoreWriter};
-use ubihome_core::PublishedMessage;
+use ubihome_core::{ChangedMessage, PublishedMessage};
 
 use crate::builtins::globals::GlobalChanged;
 use crate::builtins::{run_actions, Globals};
@@ -29,6 +31,7 @@ pub struct TemplateConfig {
     pub switches: Vec<TemplateSwitchConfig>,
     pub buttons: Vec<TemplateButtonConfig>,
     pub numbers: Vec<TemplateNumberConfig>,
+    pub sensors: Vec<TemplateSensorConfig>,
 }
 
 /// The `UbiComponent` entries every configured template entity exposes to
@@ -74,15 +77,31 @@ pub fn to_components(config: &TemplateConfig) -> Vec<UbiComponent> {
         }));
     }
 
+    for sensor in &config.sensors {
+        components.push(UbiComponent::Sensor(UbiSensor {
+            platform: "sensor".to_string(),
+            icon: sensor.icon.clone(),
+            name: sensor.name.clone().unwrap_or_default(),
+            id: sensor.get_object_id(),
+            internal: sensor.internal,
+            device_class: sensor.device_class.clone(),
+            state_class: sensor.state_class.clone(),
+            unit_of_measurement: sensor.unit_of_measurement.clone(),
+            accuracy_decimals: sensor.accuracy_decimals,
+            filters: sensor.filters.clone(),
+        }));
+    }
+
     components
 }
 
-/// Spawn the runtime handlers for every configured template switch, button
-/// and number.
+/// Spawn the runtime handlers for every configured template switch, button,
+/// number and sensor.
 pub fn spawn(
     tasks: &mut JoinSet<()>,
     config: TemplateConfig,
     tx: Sender<PublishedMessage>,
+    modules_tx: Sender<ChangedMessage>,
     globals: Globals,
     state_writer: StateStoreWriter,
 ) {
@@ -94,7 +113,8 @@ pub fn spawn(
         state_writer.clone(),
     );
     spawn_buttons(tasks, config.buttons, tx.clone(), globals.clone());
-    spawn_numbers(tasks, config.numbers, tx, globals, state_writer);
+    spawn_numbers(tasks, config.numbers, tx, globals.clone(), state_writer);
+    spawn_sensors(tasks, config.sensors, modules_tx, globals);
 }
 
 /// Spawn the runtime handler for template switches. It listens for
@@ -316,6 +336,76 @@ fn spawn_numbers(
                                 });
                             }
                         }
+                    }
+                }
+            }
+        }
+    });
+}
+
+/// Spawn the runtime handler for template sensors. Sensors are read-only, so
+/// unlike template switches/numbers there is no command to react to: the
+/// value always comes from the `lambda`'s backing global.
+///
+/// Values are published as [`ChangedMessage::SensorValueChange`] on
+/// `modules_tx`, i.e. exactly as a hardware platform module would report a
+/// reading. That routes template sensors through the same signal/filter
+/// pipeline in `crate::commands::run` that real sensors use, so `filters`
+/// and state-store mirroring work identically for both.
+fn spawn_sensors(
+    tasks: &mut JoinSet<()>,
+    sensors: Vec<TemplateSensorConfig>,
+    modules_tx: Sender<ChangedMessage>,
+    globals: Globals,
+) {
+    if sensors.is_empty() {
+        return;
+    }
+    let sensors: HashMap<String, TemplateSensorConfig> = sensors
+        .into_iter()
+        .map(|s| (s.get_object_id(), s))
+        .collect();
+    let mut global_changes = globals.subscribe();
+    tasks.spawn(async move {
+        // Publish the initial value from each sensor's backing global.
+        for (key, sensor) in &sensors {
+            if let Some(value) = globals.get_float(sensor.state_global()) {
+                log::debug!(
+                    "template sensor '{}' initial value from global '{}': {}",
+                    key,
+                    sensor.state_global(),
+                    value
+                );
+                let _ = modules_tx.send(ChangedMessage::SensorValueChange {
+                    key: key.clone(),
+                    value,
+                });
+            }
+        }
+
+        loop {
+            // A lagged receiver just misses an update; keep going.
+            let Ok(changed) = global_changes.recv().await else {
+                break;
+            };
+            let value = match changed {
+                GlobalChanged::Float { id, value } => Some((id, value as f32)),
+                GlobalChanged::Int { id, value } => Some((id, value as f32)),
+                _ => None,
+            };
+            if let Some((id, value)) = value {
+                for (key, sensor) in &sensors {
+                    if sensor.state_global() == id.as_str() {
+                        log::debug!(
+                            "template sensor '{}' value from global '{}': {}",
+                            key,
+                            id,
+                            value
+                        );
+                        let _ = modules_tx.send(ChangedMessage::SensorValueChange {
+                            key: key.clone(),
+                            value,
+                        });
                     }
                 }
             }

--- a/src/builtins/template/sensor.rs
+++ b/src/builtins/template/sensor.rs
@@ -1,0 +1,32 @@
+use garde::Validate;
+use serde::Deserialize;
+use ubihome_core::template_sensor;
+use ubihome_core::with_base_entity_properties;
+
+use crate::builtins::template::lambda::LambdaExpr;
+
+template_sensor! {
+    /// Configuration of a `sensor` entry with `platform: template`.
+    ///
+    /// Mirrors a subset of the ESPHome template sensor
+    /// (<https://esphome.io/components/sensor/template/>). Sensors are
+    /// read-only (there is no command path from a client), so - unlike the
+    /// template switch/number - the reported value always comes from a
+    /// `globals.get` `lambda`.
+    #[derive(Clone, Deserialize, Debug, Validate)]
+    #[garde(allow_unvalidated)]
+    pub struct TemplateSensorConfig {
+        /// YAML "lambda" that sources the reported value from a `float`
+        /// [`globals`](crate::builtins::globals) variable, e.g.
+        /// `lambda: { globals.get: my_value }`.
+        #[garde(dive)]
+        pub lambda: LambdaExpr,
+    }
+}
+
+impl TemplateSensorConfig {
+    /// The id of the global this sensor reads its value from.
+    pub fn state_global(&self) -> &str {
+        self.lambda.global_id()
+    }
+}

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -646,6 +646,7 @@ Remove the "{}:" entry from your configuration or install the cargo crate contai
             &mut supervised_tasks,
             builtin.template.clone(),
             internal_tx.clone(),
+            modules_tx.clone(),
             globals.clone(),
             state_writer.clone(),
         );

--- a/tests/internal/template_sensor_test.py
+++ b/tests/internal/template_sensor_test.py
@@ -1,0 +1,105 @@
+from asyncio import sleep
+from unittest.mock import Mock
+
+import aioesphomeapi
+import pytest
+
+from utils import UbiHome, fnv1_hash_object_id, run_ubihome
+
+
+async def test_template_sensor_lambda():
+    """
+    A template sensor is read-only: its reported value always comes from a
+    `globals.get` `lambda`, reporting the current value on startup and
+    updating live whenever the backing `float` global changes.
+    """
+
+    sensor_id = "room_temperature"
+    sensor_key = fnv1_hash_object_id(sensor_id)
+
+    CONFIG = f"""
+ubihome:
+  name: test_device
+
+api:
+
+globals:
+  - id: room_temperature_value
+    type: float
+    initial_value: 21.5
+
+sensor:
+  - platform: template
+    name: "Room Temperature"
+    id: {sensor_id}
+    unit_of_measurement: "°C"
+    lambda:
+      globals.get: room_temperature_value
+
+switch:
+  - platform: template
+    name: "Update Trigger"
+    id: update_trigger
+    optimistic: true
+    turn_on_action:
+      then:
+        - globals.set:
+            id: room_temperature_value
+            value: 23.4
+"""
+
+    async with UbiHome("run", config=CONFIG, wait_for_api=True) as ubihome:
+        api = aioesphomeapi.APIClient("127.0.0.1", ubihome.port, "")
+        await api.connect(login=False)
+
+        entities, _ = await api.list_entities_services()
+        sensors = [e for e in entities if isinstance(e, aioesphomeapi.SensorInfo)]
+        assert len(sensors) == 1, entities
+        entity = sensors[0]
+        assert entity.key == sensor_key
+        assert entity.unit_of_measurement == "°C"
+
+        mock = Mock()
+        api.subscribe_states(mock)
+
+        # Initial state comes from the global's `initial_value`.
+        while not mock.called:
+            await sleep(0.1)
+        assert mock.call_args.args[0].state == pytest.approx(21.5)
+        mock.reset_mock()
+
+        switch_key = fnv1_hash_object_id("update_trigger")
+        api.switch_command(switch_key, True)
+
+        while not (mock.called and mock.call_args.args[0].key == sensor_key):
+            await sleep(0.1)
+        assert mock.call_args.args[0].state == pytest.approx(23.4)
+
+
+async def test_template_sensor_validate():
+    """
+    A configuration using a template sensor with a `lambda` validates
+    successfully.
+    """
+
+    config = """
+ubihome:
+  name: test_device
+
+globals:
+  - id: room_temperature_value
+    type: float
+    initial_value: 21.5
+
+sensor:
+  - platform: template
+    name: "Room Temperature"
+    id: room_temperature
+    unit_of_measurement: "°C"
+    lambda:
+      globals.get: room_temperature_value
+"""
+    output, error = await run_ubihome("validate", config=config, extra_logging=False)
+
+    assert not error, f"Unexpected error: {error}"
+    assert "Configuration is valid." in output


### PR DESCRIPTION
## Summary
- Adds `platform: template` support for the `sensor` domain, matching the existing template switch/button/number entities.
- A template sensor is read-only: its value always comes from a `globals.get` lambda, published on startup and again whenever the backing `float` global changes.
- Values are routed through `ChangedMessage::SensorValueChange` (like a real hardware platform module would) instead of directly onto the `PublishedMessage` bus, so template sensors go through the same central signal/filter pipeline in `commands::run` as real sensors - `unit_of_measurement`, `device_class`, `state_class`, `accuracy_decimals` and `filters` (e.g. `round`) all work identically.
- Documents the new `sensor` section on the Template platform page.

## Test plan
- [x] `cargo build`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check`
- [x] `uv run pytest internal/template_sensor_test.py -vvv` (new tests: initial value from a global, live update via a switch action, config validation)
- [x] `uv run pytest internal -vvv` (no regressions in existing template/trigger tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)