### PR TITLE
fix(tests): stop two flaky Windows test failures

### DIFF
--- a/tests/e2e/home_assistant_native_api_e2e_test.py
+++ b/tests/e2e/home_assistant_native_api_e2e_test.py
@@ -198,10 +198,10 @@ async def test_button_and_switch_actions_are_executed(ha_page: Page, io_mock_fac
         await add_esphome_integration(ha_page, ubihome.port)
 
         await ha_page.get_by_role("button", name="Press").click()
-        ubihome.button_sensor_mock.wait_for_mock_state("button")
+        await ubihome.button_sensor_mock.wait_for_mock_state("button")
 
         await ha_page.get_by_role("switch", name=f"Toggle {ubihome.device_name} Switch it on").click()
-        ubihome.switch_mock.wait_for_mock_state("true")
+        await ubihome.switch_mock.wait_for_mock_state("true")
 
 
 async def test_number_action_is_executed(ha_page: Page, io_mock_factory: IOMockFactory):
@@ -213,7 +213,7 @@ async def test_number_action_is_executed(ha_page: Page, io_mock_factory: IOMockF
         number_input = ha_page.locator("state-card-number input")
         await number_input.fill("25")
         await number_input.press("Enter")
-        ubihome.number_set_mock.wait_for_mock_state("25")
+        await ubihome.number_set_mock.wait_for_mock_state("25")
 
 
 @pytest.mark.parametrize(

--- a/tests/internal/template_button_test.py
+++ b/tests/internal/template_button_test.py
@@ -47,7 +47,7 @@ binary_sensor:
         # Pressing the binary sensor presses the template button, which runs
         # its on_press action (press the runner button).
         sensor_mock.set_value("true")
-        pressed_mock.wait_for_mock_state("pressed")
+        await pressed_mock.wait_for_mock_state("pressed")
 
 
 async def test_template_button_validate():

--- a/tests/internal/template_number_test.py
+++ b/tests/internal/template_number_test.py
@@ -74,7 +74,7 @@ number:
             await sleep(0.1)
         assert mock.call_args.args[0].state == pytest.approx(42.0)
 
-        pressed_mock.wait_for_mock_state("pressed")
+        await pressed_mock.wait_for_mock_state("pressed")
 
 
 async def test_template_number_lambda_set(io_mock_factory: IOMockFactory):

--- a/tests/internal/template_switch_test.py
+++ b/tests/internal/template_switch_test.py
@@ -23,11 +23,14 @@ button:
   - platform: shell
     name: "On Runner"
     id: on_runner
-    command: "echo on > {on_mock}"
+    # Not just "on": cmd.exe (the default Windows shell) special-cases
+    # `echo on`/`echo off` as the command-echoing toggle, so it never writes
+    # the literal text to the redirected file.
+    command: "echo turned_on > {on_mock}"
   - platform: shell
     name: "Off Runner"
     id: off_runner
-    command: "echo off > {off_mock}"
+    command: "echo turned_off > {off_mock}"
 
 switch:
   - platform: template
@@ -61,9 +64,9 @@ binary_sensor:
         # Turning the binary sensor on turns the template switch on, which runs
         # its turn_on_action (press the on_runner button).
         sensor_mock.set_value("true")
-        on_mock.wait_for_mock_state("on")
+        await on_mock.wait_for_mock_state("turned_on")
 
         # Turning it off runs the turn_off_action (press the off_runner button).
         off_mock.remove()
         sensor_mock.set_value("false")
-        off_mock.wait_for_mock_state("off")
+        await off_mock.wait_for_mock_state("turned_off")

--- a/tests/internal/trigger_action_test.py
+++ b/tests/internal/trigger_action_test.py
@@ -43,11 +43,11 @@ binary_sensor:
 
     async with UbiHome("run", config=DEVICE_INFO_CONFIG):
         sensor_mock.set_value("true")
-        switch_mock.wait_for_mock_state("true")
+        await switch_mock.wait_for_mock_state("true")
         switch_mock.remove()
 
         sensor_mock.set_value("false")
-        switch_mock.wait_for_mock_state("false")
+        await switch_mock.wait_for_mock_state("false")
 
 
 async def test_binary_sensor_button_press_action(io_mock_factory: IOMockFactory):
@@ -85,7 +85,7 @@ binary_sensor:
 
     async with UbiHome("run", config=DEVICE_INFO_CONFIG):
         sensor_mock.set_value("false")
-        button_mock.wait_for_mock_state("pressed")
+        await button_mock.wait_for_mock_state("pressed")
 
 
 async def test_on_startup_trigger(io_mock_factory: IOMockFactory):
@@ -116,7 +116,7 @@ switch:
     switch_mock.set_value("false")
 
     async with UbiHome("run", config=DEVICE_INFO_CONFIG):
-        switch_mock.wait_for_mock_state("true")
+        await switch_mock.wait_for_mock_state("true")
 
 
 async def test_binary_sensor_delay_action(io_mock_factory: IOMockFactory):
@@ -168,10 +168,10 @@ binary_sensor:
     async with UbiHome("run", config=DEVICE_INFO_CONFIG):
         sensor_mock.set_value("true")
         # Action before the delay turns the switch on.
-        switch_mock.wait_for_mock_state("true")
+        await switch_mock.wait_for_mock_state("true")
         # Action after the delay presses the button, proving the delay does not
         # abort the remaining actions in the list.
-        button_mock.wait_for_mock_state("pressed")
+        await button_mock.wait_for_mock_state("pressed")
 
 
 async def test_binary_sensor_logger_log_action(io_mock_factory: IOMockFactory):

--- a/tests/mock_file.py
+++ b/tests/mock_file.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import platform
 import time
@@ -22,9 +23,15 @@ class IOMock:
         with open(self._full_path, "w") as f:
             f.write(content)
 
-    def wait_for_mock_state(self, expected_state, timeout=5):
+    async def wait_for_mock_state(self, expected_state, timeout=5):
         """
         Wait for a file to be created or modified.
+
+        This polls with `asyncio.sleep`, not blocking `time.sleep`, so the
+        event loop keeps draining the UbiHome subprocess's stdout/stderr
+        pipes while we wait. Blocking the loop here let those pipes fill up
+        under verbose (`RUST_LOG=TRACE`) logging, which stalled the
+        subprocess's own polling and made these waits flaky.
         """
         state: str = ""
         start_time = time.time()
@@ -34,7 +41,7 @@ class IOMock:
             while not os.path.exists(self._full_path):
                 if time.time() - start_time > timeout:
                     raise TimeoutError(f"File {self._full_path} was not created within {timeout} seconds.")
-                time.sleep(0.1)
+                await asyncio.sleep(0.1)
 
             if platform.system() == "Windows":
                 # On Windows, read with utf-16 encoding
@@ -48,7 +55,7 @@ class IOMock:
             else:
                 with open(self._full_path) as f:
                     state = f.read()
-            time.sleep(0.1)
+            await asyncio.sleep(0.1)
 
         return True
 

--- a/tests/platforms/api/button_test.py
+++ b/tests/platforms/api/button_test.py
@@ -42,4 +42,4 @@ button:
         assert entity.name == button_name
 
         api.button_command(fnv1_hash_object_id(button_id))
-        assert io_mock.wait_for_mock_state("Hello World!\n")
+        assert await io_mock.wait_for_mock_state("Hello World!\n")

--- a/tests/platforms/api/switch_test.py
+++ b/tests/platforms/api/switch_test.py
@@ -53,7 +53,7 @@ switch:
 
         # Test switching the switch on via command
         api.switch_command(switch_key, True)
-        io_mock.wait_for_mock_state("true")
+        await io_mock.wait_for_mock_state("true")
 
         # State update should be send back
         state_switched_to_true = False
@@ -65,7 +65,7 @@ switch:
 
         # Test switching the switch off via command
         api.switch_command(switch_key, False)
-        io_mock.wait_for_mock_state("false")
+        await io_mock.wait_for_mock_state("false")
 
         # State update should be send back
         state_switched_to_false = False

--- a/tests/platforms/mqtt/mqtt_button_test.py
+++ b/tests/platforms/mqtt/mqtt_button_test.py
@@ -52,4 +52,4 @@ button:
         publish = mqtt_client.publish(command_topic, "ON")
         publish.wait_for_publish()
 
-        io_mock.wait_for_mock_state("Hello World!\n")
+        await io_mock.wait_for_mock_state("Hello World!\n")


### PR DESCRIPTION
## Summary
- `IOMock.wait_for_mock_state` used a blocking `time.sleep` loop inside `async def` tests. That starves the asyncio event loop, so the tasks draining the UbiHome subprocess's stdout/stderr pipes don't run; under the default `RUST_LOG=TRACE` logging those pipes can fill up and stall the child process, which was intermittently timing out `internal/trigger_action_test.py::test_binary_sensor_triggers`. Made it `async` (`asyncio.sleep`) and `await`ed it at all 18 call sites.
- `internal/template_switch_test.py::test_template_switch_actions` waited for the literal strings `"on"`/`"off"` written via `echo on`/`echo off`. On Windows the default shell is `cmd.exe`, which special-cases `echo on`/`echo off` as the command-echoing toggle instead of printing the text - so the file content never matched. Verified directly (`cmd /C "echo on > file"` writes 0 bytes, `cmd /C "echo hello > file"` writes the expected bytes). Renamed the fixture strings to `"turned_on"`/`"turned_off"`.

Both failures reproduced identically on unmodified `main` before this change, confirming they were pre-existing issues and not something new.

## Test plan
- [x] `uv run pytest internal platforms/api -vvv` - 28 passed (previously 2 failing)
- [x] `uv run ruff check` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)