### PR TITLE
fix(shell): warn instead of panic on unparseable command output

### DIFF
--- a/components/shell/src/lib.rs
+++ b/components/shell/src/lib.rs
@@ -614,13 +614,25 @@ impl Module for UbiHomePlatform {
                             // TODO: Handle long running commands (e.g. newline per value) and multivalued outputs (e.g. json)
                             match output {
                                 Ok(output) => {
-                                    debug!("Sensor {} output: {}", key, output);
-                                    let value = output;
-
-                                    _ = cloned_sender.send(ChangedMessage::SensorValueChange {
-                                        key: key.clone(),
-                                        value: value.parse().unwrap(),
-                                    });
+                                    debug!("Sensor {} output: {}", key, &output);
+                                    match output.trim().parse::<f32>() {
+                                        Ok(value) => {
+                                            _ = cloned_sender.send(
+                                                ChangedMessage::SensorValueChange {
+                                                    key: key.clone(),
+                                                    value,
+                                                },
+                                            );
+                                        }
+                                        Err(e) => {
+                                            warn!(
+                                                "Sensor {} command returned unparseable output (expected parsable number) '{}': {}",
+                                                key,
+                                                output.trim(),
+                                                e
+                                            );
+                                        }
+                                    }
                                 }
                                 Err(e) => {
                                     error!("Error executing command: {}", e);
@@ -661,13 +673,17 @@ impl Module for UbiHomePlatform {
                             .await;
                             match output {
                                 Ok(output) => {
-                                    debug!("Switch {} output: {}", key, output);
+                                    debug!("Switch {} output: {}", key, &output);
                                     let value = if output.trim().to_lowercase() == "true" {
                                         true
                                     } else if output.trim().to_lowercase() == "false" {
                                         false
                                     } else {
-                                        debug!("Invalid switch sensor output: {}", output);
+                                        warn!(
+                                            "Switch {} command returned unexpected output (expected 'true'/'false'): '{}'",
+                                            key,
+                                            output.trim()
+                                        );
                                         interval.tick().await;
                                         continue;
                                     };
@@ -714,7 +730,12 @@ impl Module for UbiHomePlatform {
                                     } else if output.trim().to_lowercase() == "false" {
                                         false
                                     } else {
-                                        debug!("Invalid binary sensor output: {}", output);
+                                        warn!(
+                                            "Binary Sensor {} command returned unexpected output (expected 'true'/'false'): '{}'",
+                                            key,
+                                            output.trim()
+                                        );
+                                        interval.tick().await;
                                         continue;
                                     };
                                     debug!("Binary Sensor '{}' output: {}", key, value);
@@ -762,13 +783,17 @@ impl Module for UbiHomePlatform {
                             .await;
                             match output {
                                 Ok(output) => {
-                                    debug!("Light {} state: {}", key, output);
+                                    debug!("Light {} state: {}", key, &output);
                                     let value = if output.trim().to_lowercase() == "true" {
                                         true
                                     } else if output.trim().to_lowercase() == "false" {
                                         false
                                     } else {
-                                        debug!("Invalid light state output: {}", output);
+                                        warn!(
+                                            "Light {} command returned unexpected output (expected 'true'/'false'): '{}'",
+                                            key,
+                                            output.trim()
+                                        );
                                         interval.tick().await;
                                         continue;
                                     };
@@ -823,7 +848,7 @@ impl Module for UbiHomePlatform {
                             .await;
                             match output {
                                 Ok(output) => {
-                                    debug!("Number {} state: {}", key, output);
+                                    debug!("Number {} state: {}", key, &output);
                                     match output.trim().parse::<f32>() {
                                         Ok(value) => {
                                             _ = cloned_sender.send(
@@ -834,8 +859,9 @@ impl Module for UbiHomePlatform {
                                             );
                                         }
                                         Err(e) => {
-                                            debug!(
-                                                "Invalid number state output '{}': {}",
+                                            warn!(
+                                                "Number {} command returned unparseable output (expected parsable number) '{}': {}",
+                                                key,
                                                 output.trim(),
                                                 e
                                             );

--- a/components/shell/src/lib.rs
+++ b/components/shell/src/lib.rs
@@ -614,7 +614,7 @@ impl Module for UbiHomePlatform {
                             // TODO: Handle long running commands (e.g. newline per value) and multivalued outputs (e.g. json)
                             match output {
                                 Ok(output) => {
-                                    debug!("Sensor {} output: {}", key, &output);
+                                    debug!("Sensor {} output: {}", key, output);
                                     match output.trim().parse::<f32>() {
                                         Ok(value) => {
                                             _ = cloned_sender.send(
@@ -673,7 +673,7 @@ impl Module for UbiHomePlatform {
                             .await;
                             match output {
                                 Ok(output) => {
-                                    debug!("Switch {} output: {}", key, &output);
+                                    debug!("Switch {} output: {}", key, output);
                                     let value = if output.trim().to_lowercase() == "true" {
                                         true
                                     } else if output.trim().to_lowercase() == "false" {
@@ -783,7 +783,7 @@ impl Module for UbiHomePlatform {
                             .await;
                             match output {
                                 Ok(output) => {
-                                    debug!("Light {} state: {}", key, &output);
+                                    debug!("Light {} state: {}", key, output);
                                     let value = if output.trim().to_lowercase() == "true" {
                                         true
                                     } else if output.trim().to_lowercase() == "false" {
@@ -848,7 +848,7 @@ impl Module for UbiHomePlatform {
                             .await;
                             match output {
                                 Ok(output) => {
-                                    debug!("Number {} state: {}", key, &output);
+                                    debug!("Number {} state: {}", key, output);
                                     match output.trim().parse::<f32>() {
                                         Ok(value) => {
                                             _ = cloned_sender.send(


### PR DESCRIPTION
## Summary

Harden the `shell` platform's handling of command output so malformed output is surfaced as a warning instead of panicking the task or being silently swallowed at `debug` level.

- **Sensor**: replace the panic-prone `value.parse().unwrap()` with a safe `parse::<f32>()` that logs a `warn!` on failure instead of crashing the task.
- **Switch / Binary Sensor / Light**: unexpected (non `true`/`false`) output is now logged at `warn!` with a clear message instead of `debug!`.
- **Binary Sensor**: add the missing `interval.tick().await` before `continue` to avoid a busy-loop on bad output.
- **Number**: unparseable state output now logs a `warn!` (including the entity key) instead of `debug!`.


Relates to #142
