### PR TITLE
feat(wireguard): built-in userspace split-tunnel WireGuard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "boringtun"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15dd6a8a89cbe8997f37ca0cf035e6ea4d64cd2ecea4aed83ffb9f99f7126939"
+dependencies = [
+ "aead",
+ "base64",
+ "blake2",
+ "chacha20poly1305",
+ "hex",
+ "hmac",
+ "ip_network",
+ "ip_network_table",
+ "libc",
+ "nix 0.31.3",
+ "parking_lot",
+ "portable-atomic",
+ "rand_core 0.6.4",
+ "ring",
+ "tracing",
+ "untrusted",
+ "x25519-dalek",
+]
+
+[[package]]
 name = "borsh"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,6 +1147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1237,6 +1263,46 @@ checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "serde",
  "uuid",
+]
+
+[[package]]
+name = "defmt"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
+dependencies = [
+ "defmt 1.1.1",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1908,6 +1974,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,6 +2010,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,6 +2036,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "hostname"
@@ -2317,6 +2411,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ip_network"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
+
+[[package]]
+name = "ip_network_table"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4099b7cfc5c5e2fe8c5edf3f6f7adf7a714c9cc697534f63a5a5da30397cb2c0"
+dependencies = [
+ "ip_network",
+ "ip_network_table-deps-treebitmap",
+]
+
+[[package]]
+name = "ip_network_table-deps-treebitmap"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e537132deb99c0eb4b752f0346b6a836200eaaa3516dd7e5514b63930a09e5d"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,6 +2763,12 @@ name = "mach2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
+
+[[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "manyhow"
@@ -4880,6 +5002,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoltcp"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad095989c1533c1c266d9b1e8d70a1329dd3723c3edac6d03bbd67e7bf6f4bb"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "cfg-if",
+ "defmt 0.3.100",
+ "heapless",
+ "log",
+ "managed",
+]
+
+[[package]]
 name = "socket-pktinfo"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5652,6 +5789,7 @@ dependencies = [
  "ubihome-sendspin",
  "ubihome-shell",
  "ubihome-web_server",
+ "ubihome-wireguard",
  "windows-service",
  "windows-sys 0.59.0",
 ]
@@ -5871,6 +6009,21 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tower-http",
+ "ubihome-core",
+]
+
+[[package]]
+name = "ubihome-wireguard"
+version = "0.13.0"
+dependencies = [
+ "base64",
+ "boringtun",
+ "duration-str",
+ "garde",
+ "log",
+ "serde",
+ "smoltcp",
+ "tokio",
  "ubihome-core",
 ]
 
@@ -6919,6 +7072,7 @@ checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.6.4",
+ "serde",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ubihome-power_utils = { path = "components/power_utils" }
 ubihome-sendspin = { path = "components/sendspin" }
 ubihome-shell = { path = "components/shell" }
 ubihome-web_server = { path = "components/web_server" }
+ubihome-wireguard = { path = "components/wireguard" }
 inquire = "0.7.5"
 shell_exec = "0.2.0"
 flexi_logger = "0.29.8"
@@ -82,4 +83,5 @@ members = [
     "components/sendspin",
     "components/shell",
     "components/web_server",
+    "components/wireguard",
 ]

--- a/components/wireguard/Cargo.toml
+++ b/components/wireguard/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "ubihome-wireguard"
+version = "0.13.0"
+authors = ["Daniel Habenicht <daniel-habenicht@outlook.de>"]
+edition = "2021"
+
+[dependencies]
+log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+ubihome-core = { path = "../core", features = ["validation"] }
+duration-str = "0.16.1"
+garde = { version = "0.22.1", features = ["serde"] }
+base64 = "0.22"
+boringtun = "0.7.1"
+smoltcp = { version = "0.12", default-features = false, features = [
+    "std",
+    "log",
+    "medium-ip",
+    "proto-ipv4",
+    "proto-ipv6",
+    "socket-tcp",
+] }

--- a/components/wireguard/src/config.rs
+++ b/components/wireguard/src/config.rs
@@ -1,0 +1,218 @@
+use base64::{engine::general_purpose::STANDARD, Engine};
+use duration_str::deserialize_option_duration;
+use garde::Validate;
+use serde::Deserialize;
+use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+use std::time::Duration;
+
+/// Default WireGuard endpoint port when `peer_port` is omitted.
+const DEFAULT_PEER_PORT: u16 = 51820;
+
+/// Direction of a forward rule relative to this device.
+///
+/// * `outbound` — this device dials a service on the home network (e.g. MQTT).
+///   A local `TcpListener` is opened on `listen` and traffic is tunneled to `remote`.
+/// * `inbound` — a peer on the home network dials this device (e.g. the ESPHome
+///   API). A virtual listener is opened on the tunnel IP `listen` and each
+///   accepted connection is bridged to the local service at `remote`.
+#[derive(Clone, Copy, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Direction {
+    Outbound,
+    Inbound,
+}
+
+#[derive(Clone, Deserialize, Debug, Validate)]
+#[garde(allow_unvalidated)]
+pub struct ForwardRule {
+    pub direction: Direction,
+    /// For `outbound`: the local address to bind the TCP listener on.
+    /// For `inbound`: the tunnel IP + port to accept connections on (the IP
+    /// must equal the tunnel `address`).
+    pub listen: SocketAddr,
+    /// For `outbound`: the address on the home network to forward to.
+    /// For `inbound`: the local service to bridge accepted connections to.
+    pub remote: SocketAddr,
+}
+
+/// Configuration for the userspace WireGuard interface. Mirrors the ESPHome
+/// [`wireguard`](https://esphome.io/components/wireguard/) component's schema,
+/// with an additional `forwards` list that selects which connections are
+/// tunneled (ESPHome routes the whole interface instead).
+#[derive(Clone, Deserialize, Debug, Validate)]
+#[garde(allow_unvalidated)]
+pub struct WireGuardConfig {
+    /// This device's IPv4 address inside the tunnel, e.g. `10.9.0.2`.
+    pub address: String,
+    /// Network mask for `address`. Defaults to `255.255.255.255`.
+    pub netmask: Option<String>,
+    /// Base64 private key of this device.
+    pub private_key: String,
+    /// Hostname or IP of the remote WireGuard peer (the home server).
+    pub peer_endpoint: String,
+    /// UDP port of the remote peer. Defaults to `51820`.
+    pub peer_port: Option<u16>,
+    /// Base64 public key of the remote peer.
+    pub peer_public_key: String,
+    /// Optional base64 pre-shared key.
+    pub peer_preshared_key: Option<String>,
+    /// Persistent keep-alive interval. Disabled by default; set e.g. `25s` when
+    /// this device is behind NAT so inbound connections can reach it.
+    #[serde(default, deserialize_with = "deserialize_option_duration")]
+    pub peer_persistent_keepalive: Option<Duration>,
+    /// Networks reachable through the tunnel, in CIDR notation (e.g. `10.9.0.0/24`
+    /// or `0.0.0.0/0`). Used to route replies and outbound traffic.
+    #[serde(default)]
+    pub peer_allowed_ips: Vec<String>,
+    /// Interval at which the connection status entities are refreshed.
+    #[serde(default, deserialize_with = "deserialize_option_duration")]
+    pub update_interval: Option<Duration>,
+    /// Connections to tunnel. Each rule is an `inbound` or `outbound` forward.
+    #[garde(dive)]
+    #[serde(default)]
+    pub forwards: Vec<ForwardRule>,
+}
+
+/// Decodes a base64 WireGuard key into 32 raw bytes.
+pub fn decode_key(value: &str, what: &str) -> Result<[u8; 32], String> {
+    let bytes = STANDARD
+        .decode(value.trim())
+        .map_err(|e| format!("invalid base64 {what}: {e}"))?;
+    bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| format!("{what} must decode to 32 bytes, got {}", bytes.len()))
+}
+
+/// Parses an IPv4 dotted netmask (e.g. `255.255.255.0`) into a prefix length.
+pub fn netmask_to_prefix(netmask: &str) -> Result<u8, String> {
+    let addr: std::net::Ipv4Addr = netmask
+        .trim()
+        .parse()
+        .map_err(|e| format!("invalid netmask '{netmask}': {e}"))?;
+    let bits = u32::from(addr);
+    // A valid mask is a run of set high bits followed by zeros.
+    if bits.leading_ones() + bits.trailing_zeros() != 32 {
+        return Err(format!("netmask '{netmask}' is not contiguous"));
+    }
+    Ok(bits.leading_ones() as u8)
+}
+
+impl WireGuardConfig {
+    pub fn tunnel_ip(&self) -> Result<IpAddr, String> {
+        // Tolerate an optional `/prefix` suffix on the address.
+        let ip_part = self
+            .address
+            .split('/')
+            .next()
+            .unwrap_or(&self.address)
+            .trim();
+        ip_part
+            .parse::<IpAddr>()
+            .map_err(|e| format!("invalid address '{}': {e}", self.address))
+    }
+
+    /// On-link prefix length for the interface address, derived from `netmask`
+    /// (or an inline `address` suffix), defaulting to `/32`.
+    pub fn tunnel_prefix(&self) -> Result<u8, String> {
+        if let Some(netmask) = &self.netmask {
+            return netmask_to_prefix(netmask);
+        }
+        if let Some(suffix) = self.address.split('/').nth(1) {
+            return suffix
+                .trim()
+                .parse::<u8>()
+                .map_err(|e| format!("invalid address prefix in '{}': {e}", self.address));
+        }
+        Ok(if self.tunnel_ip()?.is_ipv4() { 32 } else { 128 })
+    }
+
+    pub fn keepalive_seconds(&self) -> Option<u16> {
+        self.peer_persistent_keepalive
+            .map(|d| d.as_secs().min(u16::MAX as u64) as u16)
+            .filter(|s| *s > 0)
+    }
+
+    /// Resolves `peer_endpoint` + `peer_port` to a concrete socket address.
+    pub fn resolve_endpoint(&self) -> Result<SocketAddr, String> {
+        let port = self.peer_port.unwrap_or(DEFAULT_PEER_PORT);
+        let host = self.peer_endpoint.trim();
+        // Accept `host` or `host:port`; an explicit port in the string wins.
+        let target = if host.parse::<SocketAddr>().is_ok() {
+            host.to_string()
+        } else {
+            format!("{host}:{port}")
+        };
+        target
+            .to_socket_addrs()
+            .map_err(|e| format!("failed to resolve peer_endpoint '{target}': {e}"))?
+            .next()
+            .ok_or_else(|| format!("peer_endpoint '{target}' resolved to no addresses"))
+    }
+
+    pub fn outbound_rules(&self) -> impl Iterator<Item = &ForwardRule> {
+        self.forwards
+            .iter()
+            .filter(|f| f.direction == Direction::Outbound)
+    }
+
+    pub fn inbound_rules(&self) -> impl Iterator<Item = &ForwardRule> {
+        self.forwards
+            .iter()
+            .filter(|f| f.direction == Direction::Inbound)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn netmask_parses_to_prefix() {
+        assert_eq!(netmask_to_prefix("255.255.255.255").unwrap(), 32);
+        assert_eq!(netmask_to_prefix("255.255.255.0").unwrap(), 24);
+        assert_eq!(netmask_to_prefix("255.255.0.0").unwrap(), 16);
+        assert_eq!(netmask_to_prefix("0.0.0.0").unwrap(), 0);
+        assert!(netmask_to_prefix("255.0.255.0").is_err());
+        assert!(netmask_to_prefix("not-a-mask").is_err());
+    }
+
+    #[test]
+    fn decode_key_requires_32_bytes() {
+        let valid = STANDARD.encode([7u8; 32]);
+        assert_eq!(decode_key(&valid, "private_key").unwrap(), [7u8; 32]);
+        let short = STANDARD.encode([1u8; 16]);
+        assert!(decode_key(&short, "private_key").is_err());
+        assert!(decode_key("!!!not-base64!!!", "private_key").is_err());
+    }
+
+    #[test]
+    fn prefix_defaults_and_suffix() {
+        let base = WireGuardConfig {
+            address: "10.9.0.2".to_string(),
+            netmask: None,
+            private_key: String::new(),
+            peer_endpoint: "h".to_string(),
+            peer_port: None,
+            peer_public_key: String::new(),
+            peer_preshared_key: None,
+            peer_persistent_keepalive: None,
+            peer_allowed_ips: vec![],
+            update_interval: None,
+            forwards: vec![],
+        };
+        assert_eq!(base.tunnel_prefix().unwrap(), 32);
+
+        let with_suffix = WireGuardConfig {
+            address: "10.9.0.2/24".to_string(),
+            ..base.clone()
+        };
+        assert_eq!(with_suffix.tunnel_prefix().unwrap(), 24);
+
+        let with_netmask = WireGuardConfig {
+            netmask: Some("255.255.0.0".to_string()),
+            ..base
+        };
+        assert_eq!(with_netmask.tunnel_prefix().unwrap(), 16);
+    }
+}

--- a/components/wireguard/src/device.rs
+++ b/components/wireguard/src/device.rs
@@ -1,0 +1,99 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use smoltcp::phy::{Device, DeviceCapabilities, Medium};
+use smoltcp::time::Instant;
+use tokio::sync::mpsc::UnboundedSender;
+
+/// Queue of inbound IP packets decapsulated from the tunnel, awaiting injection
+/// into the smoltcp stack. Filled by the WireGuard produce task, drained by the
+/// virtual interface poll loop through [`VirtualIpDevice::receive`].
+pub type InboundQueue = Arc<Mutex<VecDeque<Vec<u8>>>>;
+
+/// A smoltcp [`Device`] whose "wire" is the WireGuard tunnel: received frames come
+/// from the inbound queue, transmitted frames are handed to the WireGuard consume
+/// task over an unbounded channel to be encapsulated and sent.
+pub struct VirtualIpDevice {
+    inbound: InboundQueue,
+    outbound: UnboundedSender<Vec<u8>>,
+    mtu: usize,
+}
+
+impl VirtualIpDevice {
+    pub fn new(inbound: InboundQueue, outbound: UnboundedSender<Vec<u8>>, mtu: usize) -> Self {
+        Self {
+            inbound,
+            outbound,
+            mtu,
+        }
+    }
+}
+
+impl Device for VirtualIpDevice {
+    type RxToken<'a>
+        = RxToken
+    where
+        Self: 'a;
+    type TxToken<'a>
+        = TxToken
+    where
+        Self: 'a;
+
+    fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+        let next = self
+            .inbound
+            .lock()
+            .expect("inbound queue poisoned")
+            .pop_front();
+        next.map(|buffer| {
+            (
+                RxToken { buffer },
+                TxToken {
+                    outbound: self.outbound.clone(),
+                },
+            )
+        })
+    }
+
+    fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
+        Some(TxToken {
+            outbound: self.outbound.clone(),
+        })
+    }
+
+    fn capabilities(&self) -> DeviceCapabilities {
+        let mut cap = DeviceCapabilities::default();
+        cap.medium = Medium::Ip;
+        cap.max_transmission_unit = self.mtu;
+        cap
+    }
+}
+
+pub struct RxToken {
+    buffer: Vec<u8>,
+}
+
+impl smoltcp::phy::RxToken for RxToken {
+    fn consume<R, F>(self, f: F) -> R
+    where
+        F: FnOnce(&[u8]) -> R,
+    {
+        f(&self.buffer)
+    }
+}
+
+pub struct TxToken {
+    outbound: UnboundedSender<Vec<u8>>,
+}
+
+impl smoltcp::phy::TxToken for TxToken {
+    fn consume<R, F>(self, len: usize, f: F) -> R
+    where
+        F: FnOnce(&mut [u8]) -> R,
+    {
+        let mut buffer = vec![0u8; len];
+        let result = f(&mut buffer);
+        let _ = self.outbound.send(buffer);
+        result
+    }
+}

--- a/components/wireguard/src/iface.rs
+++ b/components/wireguard/src/iface.rs
@@ -1,0 +1,510 @@
+use std::collections::{HashMap, VecDeque};
+use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration as StdDuration;
+
+use log::{debug, error, info, warn};
+use smoltcp::iface::{Config as IfaceConfig, Interface, SocketHandle, SocketSet};
+use smoltcp::socket::tcp;
+use smoltcp::time::Instant;
+use smoltcp::wire::{HardwareAddress, IpAddress, IpCidr, IpListenEndpoint};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::sync::Notify;
+
+use crate::config::{Direction, ForwardRule};
+use crate::device::VirtualIpDevice;
+
+const SOCKET_BUFFER: usize = 65536;
+const READ_CHUNK: usize = 8192;
+
+static CONN_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Application-side data destined for a virtual socket, or a request to close it.
+enum AppMsg {
+    Data(Vec<u8>),
+    Close,
+}
+
+/// Control-plane command from an outbound TCP listener to the poll loop: open a
+/// virtual client socket connecting out through the tunnel to `remote`.
+struct OpenOutbound {
+    conn_id: u64,
+    remote: SocketAddr,
+    net_to_app: UnboundedSender<Vec<u8>>,
+}
+
+struct Conn {
+    handle: SocketHandle,
+    net_to_app: UnboundedSender<Vec<u8>>,
+    send_queue: VecDeque<Vec<u8>>,
+    closing: bool,
+}
+
+/// A single smoltcp interface that serves every forward rule: outbound client
+/// sockets (local listener → tunnel) and inbound listening sockets (tunnel →
+/// local service) share one IP stack and one virtual device.
+pub struct TcpVirtualInterface {
+    source_peer_ip: IpAddr,
+    tunnel_prefix: u8,
+    allowed_cidrs: Vec<IpCidr>,
+    default_v4: bool,
+    default_v6: bool,
+    outbound_rules: Vec<ForwardRule>,
+    inbound_rules: Vec<ForwardRule>,
+    poll_notify: Arc<Notify>,
+    commands_rx: UnboundedReceiver<OpenOutbound>,
+    commands_tx: UnboundedSender<OpenOutbound>,
+    app_to_net_rx: UnboundedReceiver<(u64, AppMsg)>,
+    app_to_net_tx: UnboundedSender<(u64, AppMsg)>,
+    next_port: u16,
+}
+
+impl TcpVirtualInterface {
+    pub fn new(
+        rules: &[ForwardRule],
+        source_peer_ip: IpAddr,
+        tunnel_prefix: u8,
+        allowed_ips: &[String],
+        poll_notify: Arc<Notify>,
+    ) -> Result<Self, String> {
+        let (commands_tx, commands_rx) = mpsc::unbounded_channel();
+        let (app_to_net_tx, app_to_net_rx) = mpsc::unbounded_channel();
+
+        let mut allowed_cidrs = Vec::new();
+        let mut default_v4 = false;
+        let mut default_v6 = false;
+        for entry in allowed_ips {
+            match parse_allowed_ip(entry)? {
+                AllowedIp::DefaultV4 => default_v4 = true,
+                AllowedIp::DefaultV6 => default_v6 = true,
+                AllowedIp::Cidr(cidr) => allowed_cidrs.push(cidr),
+            }
+        }
+
+        Ok(Self {
+            source_peer_ip,
+            tunnel_prefix,
+            allowed_cidrs,
+            default_v4,
+            default_v6,
+            outbound_rules: rules
+                .iter()
+                .filter(|r| r.direction == Direction::Outbound)
+                .cloned()
+                .collect(),
+            inbound_rules: rules
+                .iter()
+                .filter(|r| r.direction == Direction::Inbound)
+                .cloned()
+                .collect(),
+            poll_notify,
+            commands_rx,
+            commands_tx,
+            app_to_net_rx,
+            app_to_net_tx,
+            next_port: 49152,
+        })
+    }
+
+    fn alloc_port(&mut self) -> u16 {
+        let port = self.next_port;
+        self.next_port = if self.next_port >= 60999 {
+            49152
+        } else {
+            self.next_port + 1
+        };
+        port
+    }
+
+    fn interface_addresses(&self) -> Vec<IpCidr> {
+        // The tunnel address with its subnet prefix, so replies to other peers in
+        // the subnet (e.g. Home Assistant, for inbound) are treated as on-link.
+        let mut cidrs = vec![IpCidr::new(
+            IpAddress::from(self.source_peer_ip),
+            self.tunnel_prefix,
+        )];
+        let mut add = |ip: IpAddress, prefix: u8| {
+            if !cidrs.iter().any(|c| c.address() == ip) {
+                cidrs.push(IpCidr::new(ip, prefix));
+            }
+        };
+        // Networks reachable through the tunnel (peer_allowed_ips) are on-link.
+        for cidr in &self.allowed_cidrs {
+            add(cidr.address(), cidr.prefix_len());
+        }
+        // Each distinct outbound destination is reachable through the tunnel.
+        for rule in &self.outbound_rules {
+            let prefix = if rule.remote.is_ipv4() { 32 } else { 128 };
+            add(IpAddress::from(rule.remote.ip()), prefix);
+        }
+        cidrs
+    }
+
+    fn new_tcp_socket() -> tcp::Socket<'static> {
+        tcp::Socket::new(
+            tcp::SocketBuffer::new(vec![0u8; SOCKET_BUFFER]),
+            tcp::SocketBuffer::new(vec![0u8; SOCKET_BUFFER]),
+        )
+    }
+
+    /// Starts the outbound TCP listeners. Each accepts local connections and asks
+    /// the poll loop (over the command channel) to open a matching virtual socket.
+    pub async fn spawn_outbound_listeners(&self) -> Result<(), String> {
+        for rule in &self.outbound_rules {
+            let listener = TcpListener::bind(rule.listen)
+                .await
+                .map_err(|e| format!("failed to bind outbound listener on {}: {e}", rule.listen))?;
+            info!(
+                "Tunnel outbound forward listening on {} -> {}",
+                rule.listen, rule.remote
+            );
+            let remote = rule.remote;
+            let commands = self.commands_tx.clone();
+            let app_to_net = self.app_to_net_tx.clone();
+            tokio::spawn(async move {
+                loop {
+                    match listener.accept().await {
+                        Ok((stream, peer)) => {
+                            let conn_id = CONN_ID.fetch_add(1, Ordering::Relaxed);
+                            let (net_to_app_tx, net_to_app_rx) = mpsc::unbounded_channel();
+                            debug!("[{conn_id}] outbound connection from {peer} -> {remote}");
+                            if commands
+                                .send(OpenOutbound {
+                                    conn_id,
+                                    remote,
+                                    net_to_app: net_to_app_tx,
+                                })
+                                .is_err()
+                            {
+                                return;
+                            }
+                            let app_to_net = app_to_net.clone();
+                            tokio::spawn(bridge(conn_id, stream, app_to_net, net_to_app_rx));
+                        }
+                        Err(e) => {
+                            error!("outbound listener accept error: {e}");
+                            return;
+                        }
+                    }
+                }
+            });
+        }
+        Ok(())
+    }
+
+    /// Runs the smoltcp poll loop until an unrecoverable error occurs.
+    pub async fn poll_loop(mut self, mut device: VirtualIpDevice) -> Result<(), String> {
+        let iface_config = IfaceConfig::new(HardwareAddress::Ip);
+        let mut iface = Interface::new(iface_config, &mut device, Instant::now());
+        let addresses = self.interface_addresses();
+        iface.update_ip_addrs(|addrs| {
+            for cidr in addresses {
+                let _ = addrs.push(cidr);
+            }
+        });
+        // A `0.0.0.0/0` / `::/0` in peer_allowed_ips means "route everything through
+        // the tunnel": install a default route via this peer's own tunnel address.
+        if self.default_v4 {
+            if let IpAddress::Ipv4(gw) = IpAddress::from(self.source_peer_ip) {
+                let _ = iface.routes_mut().add_default_ipv4_route(gw);
+            }
+        }
+        if self.default_v6 {
+            if let IpAddress::Ipv6(gw) = IpAddress::from(self.source_peer_ip) {
+                let _ = iface.routes_mut().add_default_ipv6_route(gw);
+            }
+        }
+
+        let mut sockets = SocketSet::new(Vec::new());
+        let mut conns: HashMap<u64, Conn> = HashMap::new();
+        // Listening sockets for inbound rules: handle -> rule index.
+        let mut listeners: HashMap<SocketHandle, usize> = HashMap::new();
+
+        for (idx, rule) in self.inbound_rules.iter().enumerate() {
+            let handle = add_listen_socket(&mut sockets, self.source_peer_ip, rule.listen.port())?;
+            listeners.insert(handle, idx);
+            info!(
+                "Tunnel inbound forward listening on {} -> {}",
+                rule.listen, rule.remote
+            );
+        }
+
+        loop {
+            let timestamp = Instant::now();
+            iface.poll(timestamp, &mut device, &mut sockets);
+
+            // Promote any listening socket that received a connection into a bridged
+            // connection, and re-arm a fresh listener in its place.
+            let promoted: Vec<(SocketHandle, usize)> = listeners
+                .iter()
+                .filter(|(handle, _)| {
+                    let socket = sockets.get::<tcp::Socket>(**handle);
+                    !matches!(socket.state(), tcp::State::Listen | tcp::State::Closed)
+                })
+                .map(|(h, i)| (*h, *i))
+                .collect();
+            for (handle, idx) in promoted {
+                listeners.remove(&handle);
+                let rule = self.inbound_rules[idx].clone();
+                let conn_id = CONN_ID.fetch_add(1, Ordering::Relaxed);
+                let (net_to_app_tx, net_to_app_rx) = mpsc::unbounded_channel();
+                conns.insert(
+                    conn_id,
+                    Conn {
+                        handle,
+                        net_to_app: net_to_app_tx,
+                        send_queue: VecDeque::new(),
+                        closing: false,
+                    },
+                );
+                debug!(
+                    "[{conn_id}] inbound connection accepted on {} -> dialing {}",
+                    rule.listen, rule.remote
+                );
+                let app_to_net = self.app_to_net_tx.clone();
+                tokio::spawn(dial_and_bridge(
+                    conn_id,
+                    rule.remote,
+                    app_to_net,
+                    net_to_app_rx,
+                ));
+
+                match add_listen_socket(&mut sockets, self.source_peer_ip, rule.listen.port()) {
+                    Ok(new_handle) => {
+                        listeners.insert(new_handle, idx);
+                    }
+                    Err(e) => warn!("failed to re-arm inbound listener: {e}"),
+                }
+            }
+
+            // Pump each active connection between its smoltcp socket and its bridge.
+            let mut finished: Vec<u64> = Vec::new();
+            for (conn_id, conn) in conns.iter_mut() {
+                let socket = sockets.get_mut::<tcp::Socket>(conn.handle);
+
+                if socket.can_recv() {
+                    let received = socket.recv(|buffer| (buffer.len(), buffer.to_vec())).ok();
+                    if let Some(data) = received {
+                        if !data.is_empty() && conn.net_to_app.send(data).is_err() {
+                            // Bridge gone; tear down the socket.
+                            socket.close();
+                        }
+                    }
+                }
+
+                while socket.can_send() {
+                    let Some(front) = conn.send_queue.front() else {
+                        break;
+                    };
+                    match socket.send_slice(front) {
+                        Ok(0) => break,
+                        Ok(sent) if sent < front.len() => {
+                            let rest = front[sent..].to_vec();
+                            conn.send_queue.pop_front();
+                            conn.send_queue.push_front(rest);
+                        }
+                        Ok(_) => {
+                            conn.send_queue.pop_front();
+                        }
+                        Err(e) => {
+                            debug!("[{conn_id}] send error: {e:?}");
+                            break;
+                        }
+                    }
+                }
+
+                if conn.closing && conn.send_queue.is_empty() && socket.may_send() {
+                    socket.close();
+                }
+
+                if socket.state() == tcp::State::Closed {
+                    finished.push(*conn_id);
+                }
+            }
+            for conn_id in finished {
+                if let Some(conn) = conns.remove(&conn_id) {
+                    sockets.remove(conn.handle);
+                    debug!("[{conn_id}] connection closed");
+                }
+            }
+
+            let delay = compute_delay(&mut iface, &sockets, timestamp);
+
+            tokio::select! {
+                _ = sleep_opt(delay) => {}
+                _ = self.poll_notify.notified() => {}
+                Some(cmd) = self.commands_rx.recv() => {
+                    self.handle_open_outbound(cmd, &mut iface, &mut sockets, &mut conns);
+                }
+                Some((conn_id, msg)) = self.app_to_net_rx.recv() => {
+                    if let Some(conn) = conns.get_mut(&conn_id) {
+                        match msg {
+                            AppMsg::Data(data) => conn.send_queue.push_back(data),
+                            AppMsg::Close => conn.closing = true,
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_open_outbound(
+        &mut self,
+        cmd: OpenOutbound,
+        iface: &mut Interface,
+        sockets: &mut SocketSet<'static>,
+        conns: &mut HashMap<u64, Conn>,
+    ) {
+        let local_port = self.alloc_port();
+        let handle = sockets.add(Self::new_tcp_socket());
+        let socket = sockets.get_mut::<tcp::Socket>(handle);
+        let remote = (IpAddress::from(cmd.remote.ip()), cmd.remote.port());
+        let local = (IpAddress::from(self.source_peer_ip), local_port);
+        match socket.connect(iface.context(), remote, local) {
+            Ok(()) => {
+                conns.insert(
+                    cmd.conn_id,
+                    Conn {
+                        handle,
+                        net_to_app: cmd.net_to_app,
+                        send_queue: VecDeque::new(),
+                        closing: false,
+                    },
+                );
+            }
+            Err(e) => {
+                error!("[{}] failed to open virtual socket: {e:?}", cmd.conn_id);
+                sockets.remove(handle);
+            }
+        }
+    }
+}
+
+enum AllowedIp {
+    DefaultV4,
+    DefaultV6,
+    Cidr(IpCidr),
+}
+
+/// Parses a `peer_allowed_ips` entry in CIDR notation. A `/0` prefix is treated
+/// as a default route rather than an interface address.
+fn parse_allowed_ip(entry: &str) -> Result<AllowedIp, String> {
+    let entry = entry.trim();
+    let (addr_str, prefix_str) = entry
+        .split_once('/')
+        .ok_or_else(|| format!("peer_allowed_ips entry '{entry}' must be CIDR (ip/prefix)"))?;
+    let ip: IpAddr = addr_str
+        .trim()
+        .parse()
+        .map_err(|e| format!("invalid peer_allowed_ips entry '{entry}': {e}"))?;
+    let prefix: u8 = prefix_str
+        .trim()
+        .parse()
+        .map_err(|e| format!("invalid prefix in peer_allowed_ips entry '{entry}': {e}"))?;
+    if prefix == 0 {
+        return Ok(if ip.is_ipv4() {
+            AllowedIp::DefaultV4
+        } else {
+            AllowedIp::DefaultV6
+        });
+    }
+    Ok(AllowedIp::Cidr(IpCidr::new(IpAddress::from(ip), prefix)))
+}
+
+fn add_listen_socket(
+    sockets: &mut SocketSet<'static>,
+    ip: IpAddr,
+    port: u16,
+) -> Result<SocketHandle, String> {
+    let mut socket = TcpVirtualInterface::new_tcp_socket();
+    let endpoint = IpListenEndpoint {
+        addr: Some(IpAddress::from(ip)),
+        port,
+    };
+    socket
+        .listen(endpoint)
+        .map_err(|e| format!("failed to listen on {ip}:{port}: {e:?}"))?;
+    Ok(sockets.add(socket))
+}
+
+fn compute_delay(
+    iface: &mut Interface,
+    sockets: &SocketSet,
+    timestamp: Instant,
+) -> Option<StdDuration> {
+    // Newly queued app data wakes the loop via the app_to_net select branch, and
+    // inbound ACKs wake it via poll_notify, so honoring smoltcp's own poll delay
+    // (capped) is enough and avoids busy-spinning under TCP backpressure.
+    match iface.poll_delay(timestamp, sockets) {
+        Some(d) => {
+            Some(StdDuration::from_micros(d.total_micros()).min(StdDuration::from_millis(1000)))
+        }
+        None => Some(StdDuration::from_millis(1000)),
+    }
+}
+
+async fn sleep_opt(delay: Option<StdDuration>) {
+    match delay {
+        Some(d) => tokio::time::sleep(d).await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
+/// For inbound: dials the local service, then bridges it to the virtual socket.
+async fn dial_and_bridge(
+    conn_id: u64,
+    remote: SocketAddr,
+    app_to_net: UnboundedSender<(u64, AppMsg)>,
+    net_to_app_rx: UnboundedReceiver<Vec<u8>>,
+) {
+    match TcpStream::connect(remote).await {
+        Ok(stream) => bridge(conn_id, stream, app_to_net, net_to_app_rx).await,
+        Err(e) => {
+            error!("[{conn_id}] failed to dial local service {remote}: {e}");
+            let _ = app_to_net.send((conn_id, AppMsg::Close));
+        }
+    }
+}
+
+/// Copies bytes between a real tokio TCP stream and its virtual socket via channels.
+async fn bridge(
+    conn_id: u64,
+    mut stream: TcpStream,
+    app_to_net: UnboundedSender<(u64, AppMsg)>,
+    mut net_to_app_rx: UnboundedReceiver<Vec<u8>>,
+) {
+    let mut buf = vec![0u8; READ_CHUNK];
+    loop {
+        tokio::select! {
+            read = stream.read(&mut buf) => {
+                match read {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        if app_to_net.send((conn_id, AppMsg::Data(buf[..n].to_vec()))).is_err() {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        debug!("[{conn_id}] local read error: {e}");
+                        break;
+                    }
+                }
+            }
+            msg = net_to_app_rx.recv() => {
+                match msg {
+                    Some(data) => {
+                        if stream.write_all(&data).await.is_err() {
+                            break;
+                        }
+                    }
+                    None => break,
+                }
+            }
+        }
+    }
+    let _ = app_to_net.send((conn_id, AppMsg::Close));
+    let _ = stream.shutdown().await;
+}

--- a/components/wireguard/src/lib.rs
+++ b/components/wireguard/src/lib.rs
@@ -1,0 +1,373 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use boringtun::x25519::{PublicKey, StaticSecret};
+use log::{debug, info};
+use serde::{Deserialize, Deserializer};
+use tokio::sync::broadcast::{Receiver, Sender};
+use tokio::sync::mpsc;
+use tokio::sync::Notify;
+use tokio::time;
+
+use ubihome_core::internal::sensors::{UbiBinarySensor, UbiComponent, UbiSensor};
+use ubihome_core::{config_template, ChangedMessage, Module, NoConfig, PublishedMessage};
+
+mod config;
+mod device;
+mod iface;
+mod wg;
+
+use config::{decode_key, WireGuardConfig};
+use device::VirtualIpDevice;
+use iface::TcpVirtualInterface;
+use wg::WireGuardTunnel;
+
+config_template!(
+    wireguard,
+    WireGuardConfig,
+    NoConfig,
+    NoConfig,
+    NoConfig,
+    NoConfig,
+    NoConfig,
+    NoConfig,
+    NoConfig
+);
+
+/// Object ids of the status entities exposed by this platform.
+const STATUS_CONNECTED_ID: &str = "wireguard_status";
+const STATUS_HANDSHAKE_AGE_ID: &str = "wireguard_handshake_age";
+
+/// Default status refresh interval (ESPHome's `update_interval` default).
+const DEFAULT_STATUS_INTERVAL: Duration = Duration::from_secs(10);
+
+#[derive(Clone, Debug)]
+pub struct UbiHomePlatform {
+    config: CoreConfig,
+    components: Vec<UbiComponent>,
+}
+
+impl Module for UbiHomePlatform {
+    fn new(config_string: &str, config_path: &str) -> Result<Self, String> {
+        let config =
+            ubihome_core::validation::validate_config::<CoreConfig>(config_string, config_path)?;
+
+        // Validate keys and address eagerly so misconfiguration fails fast.
+        decode_key(&config.wireguard.private_key, "private_key")?;
+        decode_key(&config.wireguard.peer_public_key, "peer_public_key")?;
+        if let Some(psk) = &config.wireguard.peer_preshared_key {
+            decode_key(psk, "peer_preshared_key")?;
+        }
+        let source_peer_ip = config.wireguard.tunnel_ip()?;
+        config.wireguard.tunnel_prefix()?;
+        for rule in config.wireguard.inbound_rules() {
+            if rule.listen.ip() != source_peer_ip {
+                return Err(format!(
+                    "inbound forward listen address {} must use the tunnel address {}",
+                    rule.listen.ip(),
+                    source_peer_ip
+                ));
+            }
+        }
+
+        let components = vec![
+            UbiComponent::BinarySensor(UbiBinarySensor {
+                platform: "sensor".to_string(),
+                icon: Some("mdi:vpn".to_string()),
+                device_class: Some("connectivity".to_string()),
+                name: "WireGuard Status".to_string(),
+                id: STATUS_CONNECTED_ID.to_string(),
+                on_press: None,
+                on_release: None,
+                filters: None,
+            }),
+            // TODO: mark this sensor as diagnostic once core `UbiSensor` gains an
+            // `entity_category` field (see the `entity-category-diagnostic` branch);
+            // then set `entity_category: Some("diagnostic".to_string())` here.
+            UbiComponent::Sensor(UbiSensor {
+                platform: "sensor".to_string(),
+                icon: Some("mdi:timer-outline".to_string()),
+                name: "WireGuard Handshake Age".to_string(),
+                id: STATUS_HANDSHAKE_AGE_ID.to_string(),
+                state_class: Some("measurement".to_string()),
+                device_class: Some("duration".to_string()),
+                unit_of_measurement: Some("s".to_string()),
+                accuracy_decimals: Some(0),
+                filters: None,
+            }),
+        ];
+
+        Ok(UbiHomePlatform { config, components })
+    }
+
+    fn components(&mut self) -> Vec<UbiComponent> {
+        self.components.clone()
+    }
+
+    fn run(
+        &self,
+        sender: Sender<ChangedMessage>,
+        _receiver: Receiver<PublishedMessage>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static>>
+    {
+        let config = self.config.wireguard.clone();
+
+        Box::pin(async move {
+            run_tunnel(config, sender, None)
+                .await
+                .map_err(|e| -> Box<dyn std::error::Error> { e.into() })
+        })
+    }
+}
+
+async fn run_tunnel(
+    config: WireGuardConfig,
+    sender: Sender<ChangedMessage>,
+    bind_override: Option<SocketAddr>,
+) -> Result<(), String> {
+    let private = StaticSecret::from(decode_key(&config.private_key, "private_key")?);
+    let public = PublicKey::from(decode_key(&config.peer_public_key, "peer_public_key")?);
+    let preshared = config
+        .peer_preshared_key
+        .as_deref()
+        .map(|psk| decode_key(psk, "peer_preshared_key"))
+        .transpose()?;
+
+    let endpoint = config.resolve_endpoint()?;
+    let bind: SocketAddr = bind_override.unwrap_or_else(|| {
+        if endpoint.is_ipv4() {
+            "0.0.0.0:0".parse().unwrap()
+        } else {
+            "[::]:0".parse().unwrap()
+        }
+    });
+    let source_peer_ip = config.tunnel_ip()?;
+    let tunnel_prefix = config.tunnel_prefix()?;
+    let keepalive = config.keepalive_seconds();
+    let mtu = 1420;
+
+    let inbound_queue = Arc::new(std::sync::Mutex::new(std::collections::VecDeque::new()));
+    let poll_notify = Arc::new(Notify::new());
+    let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
+
+    let device = VirtualIpDevice::new(inbound_queue.clone(), outbound_tx, mtu);
+
+    let wg = WireGuardTunnel::new(
+        private,
+        public,
+        preshared,
+        keepalive,
+        0,
+        endpoint,
+        bind,
+        inbound_queue,
+        poll_notify.clone(),
+    )
+    .await?;
+
+    {
+        let wg = wg.clone();
+        tokio::spawn(async move { wg.produce_task().await });
+    }
+    {
+        let wg = wg.clone();
+        tokio::spawn(async move { wg.consume_task(outbound_rx).await });
+    }
+    {
+        let wg = wg.clone();
+        tokio::spawn(async move { wg.routine_task().await });
+    }
+
+    wg.initiate_handshake().await;
+    info!("WireGuard tunnel started to {endpoint} (peer ip {source_peer_ip}/{tunnel_prefix})");
+
+    let status_interval = config.update_interval.unwrap_or(DEFAULT_STATUS_INTERVAL);
+    spawn_status_task(wg.clone(), sender.clone(), keepalive, status_interval);
+
+    let interface = TcpVirtualInterface::new(
+        &config.forwards,
+        source_peer_ip,
+        tunnel_prefix,
+        &config.peer_allowed_ips,
+        poll_notify,
+    )?;
+    interface.spawn_outbound_listeners().await?;
+
+    interface.poll_loop(device).await
+}
+
+fn spawn_status_task(
+    wg: Arc<WireGuardTunnel>,
+    sender: Sender<ChangedMessage>,
+    keepalive: Option<u16>,
+    interval_duration: Duration,
+) {
+    // Consider the tunnel connected while the last handshake is fresh. Rekeys
+    // happen roughly every two minutes, so pad the threshold generously.
+    let stale_after = Duration::from_secs((keepalive.unwrap_or(0) as u64 * 3).max(180));
+    tokio::spawn(async move {
+        let mut interval = time::interval(interval_duration);
+        loop {
+            interval.tick().await;
+            let age = wg.handshake_age();
+            let connected = age.map(|a| a < stale_after).unwrap_or(false);
+            let age_secs = age.map(|a| a.as_secs() as f32).unwrap_or(f32::NAN);
+
+            let _ = sender.send(ChangedMessage::BinarySensorValueChange {
+                key: STATUS_CONNECTED_ID.to_string(),
+                value: connected,
+            });
+            if age_secs.is_finite() {
+                let _ = sender.send(ChangedMessage::SensorValueChange {
+                    key: STATUS_HANDSHAKE_AGE_ID.to_string(),
+                    value: age_secs,
+                });
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod e2e_tests {
+    use super::*;
+    use base64::{engine::general_purpose::STANDARD, Engine};
+    use boringtun::x25519::{PublicKey as XPublic, StaticSecret as XSecret};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream, UdpSocket};
+
+    async fn free_tcp_port() -> u16 {
+        TcpListener::bind("127.0.0.1:0")
+            .await
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    async fn free_udp_port() -> u16 {
+        UdpSocket::bind("127.0.0.1:0")
+            .await
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    fn keys(seed: u8) -> (String, String) {
+        let secret = XSecret::from([seed; 32]);
+        let public = XPublic::from(&secret);
+        (
+            STANDARD.encode(secret.to_bytes()),
+            STANDARD.encode(public.as_bytes()),
+        )
+    }
+
+    /// End-to-end: a client dials the "home" peer's outbound listener, which
+    /// tunnels through real WireGuard to the "device" peer's inbound listener,
+    /// which bridges to a local echo server. Proves both the inbound and outbound
+    /// data paths across a genuine handshake.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn forwards_tcp_through_the_tunnel() {
+        let (device_priv, device_pub) = keys(1);
+        let (home_priv, home_pub) = keys(2);
+
+        let device_udp = free_udp_port().await;
+        let home_udp = free_udp_port().await;
+        let echo_port = free_tcp_port().await;
+        let home_listen = free_tcp_port().await;
+
+        // Local echo server behind the device's inbound forward.
+        let echo = TcpListener::bind(("127.0.0.1", echo_port)).await.unwrap();
+        tokio::spawn(async move {
+            while let Ok((mut socket, _)) = echo.accept().await {
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 1024];
+                    loop {
+                        match socket.read(&mut buf).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => {
+                                if socket.write_all(&buf[..n]).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        // Device peer (10.9.0.2/32): inbound forward to the echo server. Uses a /32
+        // address + `0.0.0.0/0` allowed-ips (like a typical client config), so the
+        // reply to the home peer is routed via the installed default route.
+        let device_cfg = WireGuardConfig {
+            address: "10.9.0.2".to_string(),
+            netmask: Some("255.255.255.255".to_string()),
+            private_key: device_priv,
+            peer_endpoint: "127.0.0.1".to_string(),
+            peer_port: Some(home_udp),
+            peer_public_key: home_pub,
+            peer_preshared_key: None,
+            peer_persistent_keepalive: Some(Duration::from_secs(5)),
+            peer_allowed_ips: vec!["0.0.0.0/0".to_string()],
+            update_interval: None,
+            forwards: vec![config::ForwardRule {
+                direction: config::Direction::Inbound,
+                listen: "10.9.0.2:9000".parse().unwrap(),
+                remote: format!("127.0.0.1:{echo_port}").parse().unwrap(),
+            }],
+        };
+
+        // Home peer (10.9.0.1/32): outbound forward to the device's inbound listener.
+        // Reaches the device (10.9.0.2) via its allowed-ips host route.
+        let home_cfg = WireGuardConfig {
+            address: "10.9.0.1".to_string(),
+            netmask: Some("255.255.255.255".to_string()),
+            private_key: home_priv,
+            peer_endpoint: "127.0.0.1".to_string(),
+            peer_port: Some(device_udp),
+            peer_public_key: device_pub,
+            peer_preshared_key: None,
+            peer_persistent_keepalive: Some(Duration::from_secs(5)),
+            peer_allowed_ips: vec!["10.9.0.2/32".to_string()],
+            update_interval: None,
+            forwards: vec![config::ForwardRule {
+                direction: config::Direction::Outbound,
+                listen: format!("127.0.0.1:{home_listen}").parse().unwrap(),
+                remote: "10.9.0.2:9000".parse().unwrap(),
+            }],
+        };
+
+        let (tx, _rx) = tokio::sync::broadcast::channel(64);
+        let tx2 = tx.clone();
+
+        let device_bind: SocketAddr = format!("127.0.0.1:{device_udp}").parse().unwrap();
+        let home_bind: SocketAddr = format!("127.0.0.1:{home_udp}").parse().unwrap();
+        tokio::spawn(async move { run_tunnel(device_cfg, tx, Some(device_bind)).await });
+        tokio::spawn(async move { run_tunnel(home_cfg, tx2, Some(home_bind)).await });
+
+        // Give the handshake + listeners time to come up.
+        let mut response = Vec::new();
+        let mut ok = false;
+        for _ in 0..40 {
+            time::sleep(Duration::from_millis(250)).await;
+            if let Ok(mut stream) = TcpStream::connect(("127.0.0.1", home_listen)).await {
+                if stream.write_all(b"ping").await.is_ok() {
+                    let mut buf = [0u8; 4];
+                    if let Ok(Ok(4)) =
+                        time::timeout(Duration::from_secs(2), stream.read_exact(&mut buf)).await
+                    {
+                        response = buf.to_vec();
+                        ok = true;
+                        break;
+                    }
+                }
+            }
+        }
+        assert!(ok, "no response received through the tunnel");
+        assert_eq!(&response, b"ping");
+    }
+}

--- a/components/wireguard/src/wg.rs
+++ b/components/wireguard/src/wg.rs
@@ -1,0 +1,266 @@
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use boringtun::noise::errors::WireGuardError;
+use boringtun::noise::{Tunn, TunnResult};
+use boringtun::x25519::{PublicKey, StaticSecret};
+use log::{debug, error, warn};
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::Notify;
+use tokio::time;
+
+use crate::device::InboundQueue;
+
+const MAX_PACKET: usize = 65536;
+
+/// A userspace WireGuard tunnel: owns the boringtun state machine and the UDP
+/// socket to the endpoint. The `Tunn` state is guarded by a std `Mutex` held only
+/// across synchronous crypto — never across an `.await`.
+pub struct WireGuardTunnel {
+    peer: Mutex<Tunn>,
+    udp: UdpSocket,
+    inbound: InboundQueue,
+    poll_notify: Arc<Notify>,
+}
+
+impl WireGuardTunnel {
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new(
+        private: StaticSecret,
+        public: PublicKey,
+        preshared: Option<[u8; 32]>,
+        keepalive: Option<u16>,
+        index: u32,
+        endpoint: SocketAddr,
+        bind: SocketAddr,
+        inbound: InboundQueue,
+        poll_notify: Arc<Notify>,
+    ) -> Result<Arc<Self>, String> {
+        let peer = Tunn::new(private, public, preshared, keepalive, index, None);
+        let udp = UdpSocket::bind(bind)
+            .await
+            .map_err(|e| format!("failed to bind WireGuard UDP socket: {e}"))?;
+        udp.connect(endpoint)
+            .await
+            .map_err(|e| format!("failed to connect WireGuard UDP socket to {endpoint}: {e}"))?;
+        Ok(Arc::new(Self {
+            peer: Mutex::new(peer),
+            udp,
+            inbound,
+            poll_notify,
+        }))
+    }
+
+    /// Time since the last successful handshake, or `None` if never completed.
+    pub fn handshake_age(&self) -> Option<Duration> {
+        self.peer.lock().expect("tunn poisoned").stats().0
+    }
+
+    /// Proactively sends a handshake initiation so the tunnel comes up before any
+    /// application traffic flows.
+    pub async fn initiate_handshake(&self) {
+        let packet = {
+            let mut peer = self.peer.lock().expect("tunn poisoned");
+            let mut buf = vec![0u8; MAX_PACKET];
+            match peer.format_handshake_initiation(&mut buf, false) {
+                TunnResult::WriteToNetwork(p) => Some(p.to_vec()),
+                _ => None,
+            }
+        };
+        if let Some(p) = packet {
+            let _ = self.udp.send(&p).await;
+        }
+    }
+
+    /// Receives encrypted datagrams from the endpoint, decapsulates them, and
+    /// either replies on the wire (handshake) or enqueues the plaintext IP packet
+    /// for the smoltcp stack.
+    pub async fn produce_task(self: Arc<Self>) {
+        let mut recv_buf = vec![0u8; MAX_PACKET];
+        loop {
+            let n = match self.udp.recv(&mut recv_buf).await {
+                Ok(n) => n,
+                Err(e) => {
+                    error!("WireGuard UDP receive error: {e}");
+                    time::sleep(Duration::from_millis(500)).await;
+                    continue;
+                }
+            };
+
+            let (to_network, to_stack) = {
+                let mut peer = self.peer.lock().expect("tunn poisoned");
+                let mut to_network: Vec<Vec<u8>> = Vec::new();
+                let mut to_stack: Option<Vec<u8>> = None;
+                let mut buf = vec![0u8; MAX_PACKET];
+                match peer.decapsulate(None, &recv_buf[..n], &mut buf) {
+                    TunnResult::Done => {}
+                    TunnResult::Err(e) => debug!("WireGuard decapsulate error: {e:?}"),
+                    TunnResult::WriteToNetwork(packet) => {
+                        to_network.push(packet.to_vec());
+                        // Flush any further queued packets (repeated-call pattern).
+                        loop {
+                            let mut flush = vec![0u8; MAX_PACKET];
+                            match peer.decapsulate(None, &[], &mut flush) {
+                                TunnResult::WriteToNetwork(packet) => {
+                                    to_network.push(packet.to_vec())
+                                }
+                                _ => break,
+                            }
+                        }
+                    }
+                    TunnResult::WriteToTunnelV4(packet, _)
+                    | TunnResult::WriteToTunnelV6(packet, _) => {
+                        to_stack = Some(packet.to_vec());
+                    }
+                }
+                (to_network, to_stack)
+            };
+
+            for packet in to_network {
+                let _ = self.udp.send(&packet).await;
+            }
+            if let Some(packet) = to_stack {
+                self.inbound
+                    .lock()
+                    .expect("inbound queue poisoned")
+                    .push_back(packet);
+                self.poll_notify.notify_one();
+            }
+        }
+    }
+
+    /// Encapsulates outbound IP packets produced by the smoltcp stack and sends
+    /// them to the endpoint.
+    pub async fn consume_task(self: Arc<Self>, mut outbound: UnboundedReceiver<Vec<u8>>) {
+        while let Some(packet) = outbound.recv().await {
+            let encapsulated = {
+                let mut peer = self.peer.lock().expect("tunn poisoned");
+                let mut buf = vec![0u8; MAX_PACKET];
+                match peer.encapsulate(&packet, &mut buf) {
+                    TunnResult::WriteToNetwork(p) => Some(p.to_vec()),
+                    TunnResult::Err(e) => {
+                        debug!("WireGuard encapsulate error: {e:?}");
+                        None
+                    }
+                    _ => None,
+                }
+            };
+            if let Some(p) = encapsulated {
+                let _ = self.udp.send(&p).await;
+            }
+        }
+    }
+
+    /// Drives handshakes, keep-alives and timers.
+    pub async fn routine_task(self: Arc<Self>) {
+        loop {
+            let outcome = {
+                let mut peer = self.peer.lock().expect("tunn poisoned");
+                let mut buf = vec![0u8; MAX_PACKET];
+                match peer.update_timers(&mut buf) {
+                    TunnResult::WriteToNetwork(p) => RoutineOutcome::Send(p.to_vec()),
+                    TunnResult::Err(WireGuardError::ConnectionExpired) => {
+                        warn!("WireGuard handshake expired; re-initiating");
+                        let mut hs = vec![0u8; MAX_PACKET];
+                        match peer.format_handshake_initiation(&mut hs, false) {
+                            TunnResult::WriteToNetwork(p) => RoutineOutcome::Send(p.to_vec()),
+                            _ => RoutineOutcome::Idle,
+                        }
+                    }
+                    TunnResult::Err(e) => {
+                        debug!("WireGuard routine error: {e:?}");
+                        RoutineOutcome::Idle
+                    }
+                    _ => RoutineOutcome::Idle,
+                }
+            };
+
+            match outcome {
+                RoutineOutcome::Send(packet) => {
+                    let _ = self.udp.send(&packet).await;
+                }
+                RoutineOutcome::Idle => {}
+            }
+            time::sleep(Duration::from_millis(250)).await;
+        }
+    }
+}
+
+enum RoutineOutcome {
+    Send(Vec<u8>),
+    Idle,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+
+    fn keypair(seed: u8) -> (StaticSecret, PublicKey) {
+        let secret = StaticSecret::from([seed; 32]);
+        let public = PublicKey::from(&secret);
+        (secret, public)
+    }
+
+    async fn free_port() -> u16 {
+        tokio::net::UdpSocket::bind("127.0.0.1:0")
+            .await
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    /// Drives two real userspace WireGuard peers against each other over UDP
+    /// loopback and asserts the handshake completes on both sides.
+    #[tokio::test]
+    async fn completes_handshake_between_two_peers() {
+        let (client_secret, client_public) = keypair(1);
+        let (server_secret, server_public) = keypair(2);
+
+        let a_addr: SocketAddr = format!("127.0.0.1:{}", free_port().await).parse().unwrap();
+        let b_addr: SocketAddr = format!("127.0.0.1:{}", free_port().await).parse().unwrap();
+
+        let make = |secret, peer_public, endpoint, bind, index| {
+            let inbound = Arc::new(Mutex::new(VecDeque::new()));
+            let notify = Arc::new(Notify::new());
+            WireGuardTunnel::new(
+                secret,
+                peer_public,
+                None,
+                Some(25),
+                index,
+                endpoint,
+                bind,
+                inbound,
+                notify,
+            )
+        };
+
+        let a = make(client_secret, server_public, b_addr, a_addr, 1)
+            .await
+            .unwrap();
+        let b = make(server_secret, client_public, a_addr, b_addr, 2)
+            .await
+            .unwrap();
+
+        tokio::spawn(a.clone().produce_task());
+        tokio::spawn(a.clone().routine_task());
+        tokio::spawn(b.clone().produce_task());
+        tokio::spawn(b.clone().routine_task());
+
+        a.initiate_handshake().await;
+
+        let mut completed = false;
+        for _ in 0..50 {
+            time::sleep(Duration::from_millis(100)).await;
+            if a.handshake_age().is_some() && b.handshake_age().is_some() {
+                completed = true;
+                break;
+            }
+        }
+        assert!(completed, "WireGuard handshake did not complete within 5s");
+    }
+}

--- a/documentation/src/content/docs/features/connectivity/wireguard.md
+++ b/documentation/src/content/docs/features/connectivity/wireguard.md
@@ -1,0 +1,74 @@
+---
+title: 'WireGuard'
+tags: ['networking', 'wireguard']
+---
+
+The `wireguard` platform opens a built-in [WireGuard](https://www.wireguard.com/) tunnel to your home network entirely in userspace — no root, no `wg`/`tun` device, and no changes to the operating system's routing table. Unlike the [ESPHome WireGuard component](https://esphome.io/components/wireguard/) (whose configuration this mirrors), only the connections listed under `forwards` are sent through the tunnel, so it coexists with a corporate VPN or any other networking on the device.
+
+This is useful when UbiHome runs on a device on the public internet (or a managed corporate network) but its MQTT broker and/or Home Assistant live at home:
+
+- **inbound** forwards let a peer at home (e.g. Home Assistant) reach a service UbiHome exposes, such as the [API](/features/connectivity/api/) — the tunnel listens on your tunnel IP and bridges connections to a local port.
+- **outbound** forwards let UbiHome reach a service at home, such as an [MQTT](/features/connectivity/mqtt/) broker — a local listener is opened and traffic is tunneled to the remote address.
+
+The peer (your home WireGuard server) must have this device's public key and tunnel IP registered.
+
+```yaml
+wireguard:
+  address: 10.9.0.2 # this device's address inside the tunnel
+  netmask: 255.255.255.0 # optional, default 255.255.255.255
+  private_key: <this device's base64 private key>
+  peer_endpoint: home.example.dyndns.net
+  peer_port: 51820 # optional, default 51820
+  peer_public_key: <home server's base64 public key>
+  peer_preshared_key: <optional base64 pre-shared key>
+  peer_persistent_keepalive: 25s # recommended when behind NAT
+  peer_allowed_ips:
+    - 0.0.0.0/0 # networks reachable through the tunnel
+  forwards:
+    # Home Assistant at home -> this device's API server (inbound):
+    - direction: inbound
+      listen: '10.9.0.2:6053' # must be the tunnel `address` IP
+      remote: '127.0.0.1:6053' # the local API server
+    # This device -> MQTT broker at home (outbound):
+    - direction: outbound
+      listen: '127.0.0.1:1883' # local address to bind
+      remote: '10.0.0.10:1883' # broker on the home network
+```
+
+Point the connections you want tunneled at the forward's local side — no other configuration changes are needed. For the example above:
+
+```yaml
+api:
+  port: 6053 # reached from home via the inbound forward on 10.9.0.2:6053
+
+mqtt:
+  broker: '127.0.0.1' # the outbound forward tunnels this to 10.0.0.10:1883
+  port: 1883
+```
+
+## Options
+
+| Option                      | Description                                                                                                    |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `address`                   | This device's IPv4 address inside the tunnel, e.g. `10.9.0.2`.                                                  |
+| `netmask`                   | Network mask for `address`. Defaults to `255.255.255.255`.                                                      |
+| `private_key`               | Base64 WireGuard private key of this device.                                                                    |
+| `peer_endpoint`             | Hostname or IP of the home WireGuard server. Re-resolved on each connection.                                    |
+| `peer_port`                 | UDP port of the peer. Defaults to `51820`.                                                                      |
+| `peer_public_key`           | Base64 public key of the home WireGuard server.                                                                 |
+| `peer_preshared_key`        | Optional base64 pre-shared key.                                                                                 |
+| `peer_persistent_keepalive` | Keep-alive interval. Disabled by default; set e.g. `25s` when this device is behind NAT so inbound can reach it. |
+| `peer_allowed_ips`          | Networks reachable through the tunnel, in CIDR notation (e.g. `10.9.0.0/24` or `0.0.0.0/0`).                    |
+| `update_interval`           | Status-entity refresh interval. Defaults to `10s`.                                                             |
+| `forwards[].direction`      | `inbound` (home peer → local service) or `outbound` (local listener → home service).                           |
+| `forwards[].listen`         | Address to accept connections on. For `inbound` this must be the tunnel `address` IP; for `outbound` a local IP. |
+| `forwards[].remote`         | Address to forward to. For `inbound` the local service; for `outbound` the address on the home network.        |
+
+The platform exposes a `WireGuard Status` [binary sensor](/features/entities/binary_sensor/) (connectivity) and a `WireGuard Handshake Age` diagnostic sensor so you can monitor the tunnel's health.
+
+<!-- Backlinks to be displayed  -->
+<div style="display:none" aria-hidden="true">
+  <a href="/features/connectivity/api/">API</a>
+  <a href="/features/connectivity/mqtt/">MQTT</a>
+  <a href="/features/entities/binary_sensor/">Binary Sensor</a>
+</div>


### PR DESCRIPTION
## What & why

Adds a new `ubihome-wireguard` platform that opens a **userspace WireGuard** tunnel to a home network and forwards **only the configured connections** through it — no root, no `tun` device, no OS routing-table changes. This lets UbiHome run on a device on the public internet while its MQTT broker and/or Home Assistant live at home, without disturbing the corporate VPN or anything else on the host.

- **inbound** forwards let a peer at home (e.g. Home Assistant) reach a local service such as the ESPHome API — a virtual listener on the tunnel IP bridges to a local port.
- **outbound** forwards let the device reach a home service such as MQTT — a local listener is tunneled to a remote address.

Wiring is purely address-based, so `api`/`mqtt` need no code changes. The platform also exposes `Tunnel Connected` (connectivity binary sensor) and `Tunnel Handshake Age` sensor.
