### PR TITLE
feat(core,api): support diagnostic entity_category on sensors

### DIFF
--- a/components/api/src/lib.rs
+++ b/components/api/src/lib.rs
@@ -28,6 +28,15 @@ use log::error;
 use log::info;
 use log::warn;
 use serde::{Deserialize, Deserializer};
+use ubihome_core::configuration::base::EntityCategory as UbiEntityCategory;
+
+fn entity_category_from(category: Option<UbiEntityCategory>) -> i32 {
+    match category.unwrap_or_default() {
+        UbiEntityCategory::Diagnostic => EntityCategory::Diagnostic as i32,
+        UbiEntityCategory::Config => EntityCategory::Config as i32,
+        UbiEntityCategory::None => EntityCategory::None as i32,
+    }
+}
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::num::ParseIntError;
@@ -220,7 +229,9 @@ impl Module for UbiHomePlatform {
                                     icon: switch_entity.icon.unwrap_or_default(),
                                     device_class: switch_entity.device_class.unwrap_or_default(),
                                     disabled_by_default: false,
-                                    entity_category: EntityCategory::None as i32,
+                                    entity_category: entity_category_from(
+                                        switch_entity.entity_category,
+                                    ),
                                     assumed_state: switch_entity.assumed_state,
                                 },
                             );
@@ -238,7 +249,7 @@ impl Module for UbiHomePlatform {
                                     icon: button.icon.unwrap_or_default(),
                                     device_class: "".to_string(),
                                     disabled_by_default: false,
-                                    entity_category: EntityCategory::None as i32,
+                                    entity_category: entity_category_from(button.entity_category),
                                 },
                             );
                             api_components_by_key.insert(key, component_button);
@@ -264,7 +275,7 @@ impl Module for UbiHomePlatform {
                                     legacy_last_reset_type: SensorLastResetType::LastResetNone
                                         as i32,
                                     disabled_by_default: false,
-                                    entity_category: EntityCategory::None as i32,
+                                    entity_category: entity_category_from(sensor.entity_category),
                                 },
                             );
                             api_components_by_key.insert(key, component_sensor);
@@ -285,7 +296,9 @@ impl Module for UbiHomePlatform {
                                             .unwrap_or("".to_string()),
                                         is_status_binary_sensor: false,
                                         disabled_by_default: false,
-                                        entity_category: EntityCategory::None as i32,
+                                        entity_category: entity_category_from(
+                                            binary_sensor.entity_category,
+                                        ),
                                     },
                                 );
                             api_components_by_key.insert(key, component_binary_sensor);
@@ -302,7 +315,7 @@ impl Module for UbiHomePlatform {
                                     device_id: 0,
                                     icon: light.icon.unwrap_or_default(),
                                     disabled_by_default: false,
-                                    entity_category: EntityCategory::None as i32,
+                                    entity_category: entity_category_from(light.entity_category),
                                     supported_color_modes: vec![],
                                     min_mireds: 153.0,
                                     max_mireds: 500.0,
@@ -329,7 +342,7 @@ impl Module for UbiHomePlatform {
                                     max_value: number.max_value,
                                     step: number.step,
                                     disabled_by_default: false,
-                                    entity_category: EntityCategory::None as i32,
+                                    entity_category: entity_category_from(number.entity_category),
                                     unit_of_measurement: number
                                         .unit_of_measurement
                                         .unwrap_or_default(),
@@ -351,7 +364,9 @@ impl Module for UbiHomePlatform {
                                         device_id: 0,
                                         icon: text_sensor.icon.unwrap_or_default(),
                                         disabled_by_default: false,
-                                        entity_category: EntityCategory::None as i32,
+                                        entity_category: entity_category_from(
+                                            text_sensor.entity_category,
+                                        ),
                                         device_class: text_sensor.device_class.unwrap_or_default(),
                                     },
                                 );

--- a/components/bme280/src/lib.rs
+++ b/components/bme280/src/lib.rs
@@ -105,6 +105,7 @@ impl Module for UbiHomePlatform {
                     accuracy_decimals: None,
                     device_class: None,
                     unit_of_measurement: None,
+                    entity_category: None,
                     filters: None,
                     platform: "bme280".to_string(),
                 });
@@ -142,6 +143,7 @@ impl Module for UbiHomePlatform {
                 name: temperature.name.clone().unwrap_or_default(),
                 internal: temperature.internal,
                 id: object_id.clone(),
+                entity_category: temperature.entity_category,
                 filters: temperature.filters.clone(),
             }));
             let pressure = n_sensor.pressure.clone().unwrap_or(SpecificSensorConfig {
@@ -153,6 +155,7 @@ impl Module for UbiHomePlatform {
                 accuracy_decimals: None,
                 device_class: None,
                 unit_of_measurement: None,
+                entity_category: None,
                 filters: None,
                 platform: "bme280".to_string(),
             });
@@ -190,6 +193,7 @@ impl Module for UbiHomePlatform {
                 name: pressure.name.clone().unwrap_or_default(),
                 internal: pressure.internal,
                 id: id.clone(),
+                entity_category: pressure.entity_category,
                 filters: pressure.filters.clone(),
             }));
             let humidity = n_sensor.humidity.clone().unwrap_or(SpecificSensorConfig {
@@ -201,6 +205,7 @@ impl Module for UbiHomePlatform {
                 accuracy_decimals: None,
                 device_class: None,
                 unit_of_measurement: None,
+                entity_category: None,
                 filters: None,
                 platform: "bme280".to_string(),
             });
@@ -237,6 +242,7 @@ impl Module for UbiHomePlatform {
                 name: humidity.name.clone().unwrap_or_default(),
                 internal: humidity.internal,
                 id: id.clone(),
+                entity_category: humidity.entity_category,
                 filters: humidity.filters.clone(),
             }));
             let sensor_entry = BME280Sensor {

--- a/components/core/src/configuration/base.rs
+++ b/components/core/src/configuration/base.rs
@@ -1,3 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+/// Home Assistant entity category. Controls whether an entity is shown among
+/// the primary controls (`None`) or under the Config / Diagnostic sections.
+///
+/// See <https://developers.home-assistant.io/docs/core/entity/#registry-properties>.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EntityCategory {
+    #[default]
+    None,
+    Config,
+    Diagnostic,
+}
+
 /// Macro to add base entity properties (id, name, internal, platform) to a
 /// struct.
 ///
@@ -56,6 +71,10 @@ macro_rules! with_base_entity_properties {
                 #[garde(ascii)]
                 pub device_class: Option<String>,
 
+                /// Home Assistant entity category (`config` or `diagnostic`).
+                #[garde(skip)]
+                pub entity_category: Option<$crate::configuration::base::EntityCategory>,
+
 
                 $(
                     $(#[$field_meta])*
@@ -87,6 +106,7 @@ macro_rules! with_base_entity_properties {
                 platform: String,
                 icon: Option<String>,
                 device_class: Option<String>,
+                entity_category: Option<$crate::configuration::base::EntityCategory>,
                 $(
                     $(#[$field_meta])*
                     $field_name : $field_type,
@@ -110,6 +130,7 @@ macro_rules! with_base_entity_properties {
                         platform: shadow.platform,
                         icon: shadow.icon,
                         device_class: shadow.device_class,
+                        entity_category: shadow.entity_category,
                         $(
                             $field_name: shadow.$field_name,
                         )*
@@ -361,6 +382,7 @@ macro_rules! template_light {
 
 #[cfg(test)]
 mod entity_tests {
+    use super::EntityCategory;
     use garde::Validate;
 
     with_base_entity_properties! {
@@ -417,5 +439,31 @@ mod entity_tests {
         let err = parse(r#"{"platform":"probe","name":"x","pin":5,"bogus":9}"#)
             .expect_err("unknown field must still be rejected");
         assert!(err.contains("bogus"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn entity_category_defaults_to_none_when_absent() {
+        let p = parse(r#"{"platform":"probe","name":"x","pin":5}"#).unwrap();
+        assert_eq!(p.entity_category, None);
+    }
+
+    #[test]
+    fn entity_category_accepts_valid_variants() {
+        let p = parse(r#"{"platform":"probe","name":"x","pin":5,"entity_category":"diagnostic"}"#)
+            .unwrap();
+        assert_eq!(p.entity_category, Some(EntityCategory::Diagnostic));
+        let p =
+            parse(r#"{"platform":"probe","name":"x","pin":5,"entity_category":"config"}"#).unwrap();
+        assert_eq!(p.entity_category, Some(EntityCategory::Config));
+    }
+
+    #[test]
+    fn entity_category_rejects_invalid_values() {
+        let err = parse(r#"{"platform":"probe","name":"x","pin":5,"entity_category":"bogus"}"#)
+            .expect_err("invalid entity_category must be rejected");
+        assert!(
+            err.contains("entity_category") || err.contains("bogus") || err.contains("variant"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/components/core/src/internal/sensors.rs
+++ b/components/core/src/internal/sensors.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    configuration::base::EntityCategory,
     configuration::binary_sensor::{BinarySensorFilter, Trigger},
     configuration::sensor::SensorFilter,
 };
@@ -59,6 +60,9 @@ macro_rules! with_base_properties {
             /// components (api, mqtt, http).
             #[serde(default)]
             pub internal: bool,
+            /// Home Assistant entity category (`config` or `diagnostic`).
+            #[serde(default)]
+            pub entity_category: Option<EntityCategory>,
         // pub state_class: Option<String>,
         // pub device_class: Option<String>,
 

--- a/components/gpio/src/lib.rs
+++ b/components/gpio/src/lib.rs
@@ -136,6 +136,7 @@ impl Module for UbiHomePlatform {
                 name: binary_sensor.name.clone().unwrap_or_default(),
                 internal: binary_sensor.internal,
                 id: id.clone(),
+                entity_category: binary_sensor.entity_category,
                 on_press: binary_sensor.on_press.clone(),
                 on_release: binary_sensor.on_release.clone(),
                 filters: binary_sensor.filters.clone(),
@@ -159,6 +160,7 @@ impl Module for UbiHomePlatform {
                 name: switch.name.clone().unwrap_or_default(),
                 internal: switch.internal,
                 id: id.clone(),
+                entity_category: switch.entity_category,
                 assumed_state: false,
             }));
             debug!(

--- a/components/illuminance/src/lib.rs
+++ b/components/illuminance/src/lib.rs
@@ -90,6 +90,7 @@ impl Module for UbiHomePlatform {
                     name: sensor.name.clone().unwrap_or_default(),
                     internal: sensor.internal,
                     id: id.clone(),
+                    entity_category: None,
                     filters: sensor.filters.clone(),
                 }));
                 sensors.insert(id.clone(), sensor);

--- a/components/online/src/lib.rs
+++ b/components/online/src/lib.rs
@@ -172,6 +172,7 @@ impl Module for UbiHomePlatform {
                 name: binary_sensor.name.clone().unwrap_or_default(),
                 internal: binary_sensor.internal,
                 id: id.clone(),
+                entity_category: binary_sensor.entity_category,
                 on_press: binary_sensor.on_press.clone(),
                 on_release: binary_sensor.on_release.clone(),
                 filters: binary_sensor.filters.clone(),

--- a/components/power_utils/src/lib.rs
+++ b/components/power_utils/src/lib.rs
@@ -76,6 +76,7 @@ impl Module for UbiHomePlatform {
             let id = button.get_object_id();
             let name = button.name.clone().unwrap_or_default();
             let internal = button.internal;
+            let entity_category = button.entity_category;
             let button_component = match button.action {
                 PowerAction::Reboot => UbiButton {
                     platform: "sensor".to_string(),
@@ -83,6 +84,7 @@ impl Module for UbiHomePlatform {
                     name,
                     internal,
                     id: id.clone(),
+                    entity_category,
                 },
                 PowerAction::Shutdown => UbiButton {
                     platform: "sensor".to_string(),
@@ -90,6 +92,7 @@ impl Module for UbiHomePlatform {
                     name,
                     internal,
                     id: id.clone(),
+                    entity_category,
                 },
                 PowerAction::Hibernate => UbiButton {
                     platform: "sensor".to_string(),
@@ -97,6 +100,7 @@ impl Module for UbiHomePlatform {
                     name,
                     internal,
                     id: id.clone(),
+                    entity_category,
                 },
                 PowerAction::Logout => UbiButton {
                     platform: "sensor".to_string(),
@@ -104,6 +108,7 @@ impl Module for UbiHomePlatform {
                     name,
                     internal,
                     id: id.clone(),
+                    entity_category,
                 },
                 PowerAction::Sleep => UbiButton {
                     platform: "sensor".to_string(),
@@ -111,6 +116,7 @@ impl Module for UbiHomePlatform {
                     name,
                     internal,
                     id: id.clone(),
+                    entity_category,
                 },
             };
 

--- a/components/sendspin/src/lib.rs
+++ b/components/sendspin/src/lib.rs
@@ -682,6 +682,7 @@ impl Module for UbiHomePlatform {
                     name: cfg.name.unwrap_or_default(),
                     internal: cfg.internal,
                     id,
+                    entity_category: cfg.entity_category,
                     on_play: cfg.on_play,
                     on_pause: cfg.on_pause,
                     on_volume_change: cfg.on_volume_change,

--- a/components/shell/src/lib.rs
+++ b/components/shell/src/lib.rs
@@ -202,6 +202,7 @@ impl Module for UbiHomePlatform {
                 name: sensor.name.clone().unwrap_or_default(),
                 internal: sensor.internal,
                 id: id.clone(),
+                entity_category: sensor.entity_category,
                 filters: sensor.filters.clone(),
             }));
             sensors.insert(id.clone(), sensor);
@@ -217,6 +218,7 @@ impl Module for UbiHomePlatform {
                 name: binary_sensor.name.clone().unwrap_or_default(),
                 internal: binary_sensor.internal,
                 id: id.clone(),
+                entity_category: binary_sensor.entity_category,
                 on_press: binary_sensor.on_press.clone(),
                 on_release: binary_sensor.on_release.clone(),
                 filters: binary_sensor.filters.clone(),
@@ -233,6 +235,7 @@ impl Module for UbiHomePlatform {
                 name: button.name.clone().unwrap_or_default(),
                 internal: button.internal,
                 id: id.clone(),
+                entity_category: button.entity_category,
             }));
             buttons.insert(id.clone(), button);
         }
@@ -246,6 +249,7 @@ impl Module for UbiHomePlatform {
                 name: switch.name.clone().unwrap_or_default(),
                 internal: switch.internal,
                 id: id.clone(),
+                entity_category: switch.entity_category,
                 device_class: None,
                 assumed_state: switch.command_state.is_none(),
             }));
@@ -261,6 +265,7 @@ impl Module for UbiHomePlatform {
                 name: light.name.clone().unwrap_or_default(),
                 internal: light.internal,
                 id: id.clone(),
+                entity_category: light.entity_category,
                 disabled_by_default: light.disabled_by_default.unwrap_or(true),
             }));
             lights.insert(id.clone(), light);
@@ -275,6 +280,7 @@ impl Module for UbiHomePlatform {
                 name: number.name.clone().unwrap_or_default(),
                 internal: number.internal,
                 id: id.clone(),
+                entity_category: number.entity_category,
                 min_value: number.min_value.unwrap_or(0.0),
                 max_value: number.max_value.unwrap_or(100.0),
                 step: number.step.unwrap_or(1.0),
@@ -294,6 +300,7 @@ impl Module for UbiHomePlatform {
                 name: text_sensor.name.clone().unwrap_or_default(),
                 internal: text_sensor.internal,
                 id: id.clone(),
+                entity_category: text_sensor.entity_category,
                 device_class: text_sensor.device_class.clone(),
             }));
             text_sensors.insert(id.clone(), text_sensor);

--- a/src/builtins/template/mod.rs
+++ b/src/builtins/template/mod.rs
@@ -46,6 +46,7 @@ pub fn to_components(config: &TemplateConfig) -> Vec<UbiComponent> {
             name: switch.name.clone().unwrap_or_default(),
             id: switch.get_object_id(),
             internal: switch.internal,
+            entity_category: switch.entity_category,
             device_class: switch.device_class.clone(),
             assumed_state: switch.is_assumed_state(),
         }));
@@ -58,6 +59,7 @@ pub fn to_components(config: &TemplateConfig) -> Vec<UbiComponent> {
             name: button.name.clone().unwrap_or_default(),
             id: button.get_object_id(),
             internal: button.internal,
+            entity_category: button.entity_category,
         }));
     }
 
@@ -68,6 +70,7 @@ pub fn to_components(config: &TemplateConfig) -> Vec<UbiComponent> {
             name: number.name.clone().unwrap_or_default(),
             id: number.get_object_id(),
             internal: number.internal,
+            entity_category: number.entity_category,
             min_value: number.min_value.unwrap_or(0.0),
             max_value: number.max_value.unwrap_or(100.0),
             step: number.step.unwrap_or(1.0),
@@ -88,6 +91,7 @@ pub fn to_components(config: &TemplateConfig) -> Vec<UbiComponent> {
             state_class: sensor.state_class.clone(),
             unit_of_measurement: sensor.unit_of_measurement.clone(),
             accuracy_decimals: sensor.accuracy_decimals,
+            entity_category: sensor.entity_category,
             filters: sensor.filters.clone(),
         }));
     }


### PR DESCRIPTION
## What & why

Adds an optional `entity_category` field to the core `UbiSensor` and maps it in the ESPHome native API discovery (`components/api`), which previously hardcoded every entity to `EntityCategory::None`. Sensors can now be surfaced in Home Assistant's **Diagnostic** (or Config) category.

