### PR TITLE
feat(power_utils): add restart_service action

### DIFF
--- a/components/power_utils/src/lib.rs
+++ b/components/power_utils/src/lib.rs
@@ -22,11 +22,55 @@ use system_shutdown::sleep;
 #[garde(allow_unvalidated)]
 pub struct PowerUtilsConfig {}
 
+/// Restarts UbiHome by re-executing the current binary. On Unix the image is
+/// replaced in place; on a Windows terminal a new process is spawned; as a
+/// Windows service it exits so the service controller restarts it. On failure
+/// it logs the error and keeps running.
+fn restart_process() {
+    info!("Restart requested - restarting UbiHome process");
+
+    let exe = match std::env::current_exe() {
+        Ok(exe) => exe,
+        Err(err) => {
+            error!("Could not restart UbiHome: failed to resolve current executable: {err}");
+            return;
+        }
+    };
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // `exec` replaces the image in place; it only returns on failure.
+        let err = std::process::Command::new(&exe).args(&args).exec();
+        error!("Could not restart UbiHome: {err}");
+    }
+
+    #[cfg(not(unix))]
+    {
+        // Exit so the Windows service controller restarts us (the only way).
+        if args
+            .iter()
+            .any(|arg| arg.as_str() == "--as-windows-service")
+        {
+            std::process::exit(0);
+        }
+
+        match std::process::Command::new(&exe).args(&args).spawn() {
+            Ok(_) => std::process::exit(0),
+            Err(err) => error!("Could not restart UbiHome: failed to spawn new process: {err}"),
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, Deserialize, Validate)]
 #[serde(rename_all = "camelCase")]
 pub enum PowerAction {
     #[serde(alias = "reboot", alias = "restart")]
     Reboot,
+    /// Restarts the UbiHome process itself (not the machine).
+    #[serde(rename = "restart_service")]
+    RestartService,
     #[serde(alias = "shutdown")]
     Shutdown,
     #[serde(alias = "hibernate")]
@@ -80,6 +124,13 @@ impl Module for UbiHomePlatform {
                 PowerAction::Reboot => UbiButton {
                     platform: "sensor".to_string(),
                     icon: Some(button.icon.unwrap_or("mdi:restart".to_string())),
+                    name,
+                    internal,
+                    id: id.clone(),
+                },
+                PowerAction::RestartService => UbiButton {
+                    platform: "sensor".to_string(),
+                    icon: Some(button.icon.unwrap_or("mdi:reload".to_string())),
                     name,
                     internal,
                     id: id.clone(),
@@ -153,6 +204,9 @@ impl Module for UbiHomePlatform {
                                             Ok(_) => debug!("Rebooting."),
                                             Err(error) => error!("Failed to reboot: {}", error),
                                         }
+                                    }
+                                    PowerAction::RestartService => {
+                                        restart_process();
                                     }
                                     PowerAction::Shutdown => {
                                         debug!("Shutting down...");

--- a/documentation/src/content/docs/features/platforms/power_utils.md
+++ b/documentation/src/content/docs/features/platforms/power_utils.md
@@ -19,6 +19,11 @@ button:
     name: 'Reboot'
     action: reboot
 
+  # Restarts the UbiHome process itself (not the machine).
+  - platform: power_utils
+    name: 'Restart UbiHome'
+    action: restart_service
+
   - platform: power_utils
     name: 'Logout'
     action: logout

--- a/tests/platforms/power_utils/restart_test.py
+++ b/tests/platforms/power_utils/restart_test.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from utils import UbiHome
+
+
+async def test_restart_service_button():
+    """
+    Test that the power_utils `restart_service` button restarts the UbiHome
+    process (not the machine).
+
+    The process re-executes itself (same PID, same stdout), so the startup
+    banner is printed again. `on_startup` presses the button after a short
+    delay, so the banner appearing a second time proves the process restarted.
+    """
+
+    DEVICE_INFO_CONFIG = """
+ubihome:
+  name: test_device
+  on_startup:
+    then:
+      - delay: 2s
+      - button.press: restart_service_btn
+
+power_utils:
+
+button:
+  - platform: power_utils
+    name: "Restart UbiHome"
+    id: restart_service_btn
+    action: restart_service
+"""
+
+    async with UbiHome("run", config=DEVICE_INFO_CONFIG) as ubihome:
+
+        async def wait_for_restart():
+            while (ubihome.stdout or "").count("UbiHome - ") < 2:
+                await asyncio.sleep(0.1)
+
+        await asyncio.wait_for(wait_for_restart(), timeout=15)


### PR DESCRIPTION
Adds a `restart_service` power action that restarts the UbiHome process itself (distinct from `reboot`, which reboots the machine) by re-executing the current binary with the same arguments. On Unix the process image is replaced in place (same PID); on Windows it exits so a plain-terminal run spawns a fresh process, and under the SCM lets the service's failure actions restart it.

Exposed as a button entity, so it can be triggered from any automation via `button.press`.