### PR TITLE
fix(sendspin): release audio device when playback stops

### DIFF
--- a/components/sendspin/src/lib.rs
+++ b/components/sendspin/src/lib.rs
@@ -30,8 +30,11 @@ type ClockSyncRef = Arc<parking_lot::Mutex<ClockSync>>;
 enum PlayerCommand {
     /// Enqueue an audio buffer for playback
     Enqueue(AudioBuffer),
-    /// Clear the player buffer
+    /// Clear the player buffer (stream continues, e.g. a seek)
     Clear,
+    /// Tear down the player and release the audio device (stream truly
+    /// ended, e.g. pause/stop or a lost connection)
+    Stop,
     /// Initialize the player with the given format and clock sync
     Init(AudioFormat, ClockSyncRef),
     /// Set the player volume (0-100)
@@ -244,6 +247,16 @@ async fn run_player(cfg: PlayerRuntimeConfig, changed_tx: Sender<ChangedMessage>
                         log::warn!("Player not initialized yet, cannot clear");
                     }
                 }
+                PlayerCommand::Stop => {
+                    // Dropping the player releases its cpal stream (and the
+                    // underlying ALSA device). Leaving it alive here left an
+                    // idle exclusive `hw:` device open: it produced periodic
+                    // underrun clicks and made the next Init fail with
+                    // "device busy" since the old stream was never closed.
+                    if synced_player.take().is_some() {
+                        debug!("Audio output stopped, device released");
+                    }
+                }
                 PlayerCommand::SetVolume(vol) => {
                     current_volume = vol;
                     if let Some(ref mut player) = synced_player {
@@ -326,10 +339,10 @@ async fn run_player(cfg: PlayerRuntimeConfig, changed_tx: Sender<ChangedMessage>
 
         info!("Waiting for stream to start...");
 
-        // Clear any audio left buffered from a previous connection. Skip it
+        // Release any player left over from a previous connection. Skip it
         // until a player exists, otherwise this warns on every startup.
         if player_ever_initialized {
-            let _ = player_tx.send(PlayerCommand::Clear);
+            let _ = player_tx.send(PlayerCommand::Stop);
         }
 
         // Message handling variables (reset for each connection)
@@ -421,7 +434,7 @@ async fn run_player(cfg: PlayerRuntimeConfig, changed_tx: Sender<ChangedMessage>
                         }
                         Message::StreamEnd(stream_end) => {
                             debug!("Stream ended: {:?}", stream_end.roles);
-                            let _ = player_tx.send(PlayerCommand::Clear);
+                            let _ = player_tx.send(PlayerCommand::Stop);
                             buffered_duration_us = 0;
                             playback_started = false;
                             first_chunk_logged = false;
@@ -644,7 +657,7 @@ async fn run_player(cfg: PlayerRuntimeConfig, changed_tx: Sender<ChangedMessage>
             server, backoff
         );
         if player_ever_initialized {
-            let _ = player_tx.send(PlayerCommand::Clear);
+            let _ = player_tx.send(PlayerCommand::Stop);
         }
         tokio::time::sleep(backoff).await;
         backoff = (backoff * 2).min(max_backoff);


### PR DESCRIPTION
## Summary
- Pausing/stopping playback only cleared the player's queue but never dropped the underlying `SyncedPlayer`/`cpal::Stream`, leaving an idle stream open on the exclusive `alsa:hw:...` device.
- The idle, unfed stream underran the DAC once per buffer period, producing a repeating beep/click for as long as playback stayed paused.
- The `EBUSY` ("device busy") error seen in the logs around the same time was a transient race from that same leftover stream not having fully closed yet, not a permanent block — resuming playback shortly after still worked fine, since by then the device had been released.
- Added a `PlayerCommand::Stop` that actually drops the player (releasing the device), used on real stream end (`StreamEnd`) and on connection loss/reconnect. `StreamClear` (e.g. a seek) still uses the lighter `Clear` so the device stays open and playback doesn't hiccup mid-stream.

## Test plan
- [x] `cargo check -p ubihome-sendspin`
- [x] `cargo clippy -p ubihome-sendspin --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -p ubihome-sendspin -- --check`
- [ ] Manual verification on real HiFiBerry hardware: pause playback and confirm the periodic beep no longer occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)