### PR TITLE
feat(shell): log both stdout and stderr on failure, add parse_stderr fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4769,9 +4769,8 @@ dependencies = [
 
 [[package]]
 name = "shell_exec"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f66f85f865342648a1f73b9ab8bef96fcc1142fc50c7b379ab80275d49defea"
+version = "0.3.0"
+source = "git+https://github.com/DanielHabenicht/fork.shell_exec?branch=stream-stdout-stderr#dd319301ce2d96adeab53e92a3f3a8028efce4f3"
 dependencies = [
  "bstr",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ ubihome-sendspin = { path = "components/sendspin" }
 ubihome-shell = { path = "components/shell" }
 ubihome-web_server = { path = "components/web_server" }
 inquire = "0.7.5"
-shell_exec = "0.2.0"
+shell_exec = { git = "https://github.com/DanielHabenicht/fork.shell_exec", branch = "stream-stdout-stderr" }
 flexi_logger = "0.29.8"
 directories = "6.0.0"
 futures-signals = "0.3.34"

--- a/components/shell/Cargo.toml
+++ b/components/shell/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
-shell_exec = "0.2.0"
+shell_exec = { git = "https://github.com/DanielHabenicht/fork.shell_exec", branch = "stream-stdout-stderr" }
 ubihome-core = { path = "../core", features = ["validation"] }
 tokio = { version = "1", features = ["full"] }
 duration-str = "0.16.1"

--- a/components/shell/src/lib.rs
+++ b/components/shell/src/lib.rs
@@ -3,7 +3,7 @@ use log::{debug, error, trace, warn};
 use serde::{Deserialize, Deserializer};
 use shell_exec::{Execution, Shell, ShellError};
 use std::collections::HashMap;
-use std::{future::Future, pin::Pin, str, time::Duration};
+use std::{future::Future, pin::Pin, time::Duration};
 use tokio::{
     sync::broadcast::{Receiver, Sender},
     time,
@@ -48,6 +48,10 @@ pub struct ShellConfig {
     #[serde(deserialize_with = "deserialize_duration")]
     #[garde(skip)]
     pub timeout: Duration,
+
+    #[serde(default)]
+    #[garde(skip)]
+    pub parse_stderr: bool,
 }
 
 fn default_timeout() -> Duration {
@@ -952,10 +956,32 @@ async fn execute_command(
         .build();
 
     trace!("Executing command: {}", command);
-    let output = execution.execute(b"").await?;
-    let output_string = str::from_utf8(&output).unwrap_or("");
-    trace!("Command '{}' executed: {}", command, output_string);
-    Ok(output_string.to_string())
+    let output = execution.execute_full(Vec::new()).await?;
+    let stdout = String::from_utf8_lossy(&output.stdout)
+        .trim_end()
+        .to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr)
+        .trim_end()
+        .to_string();
+
+    if !output.success {
+        return Err(ShellError::Failure(format!(
+            "stdout: '{}', stderr: '{}'",
+            stdout, stderr
+        )));
+    }
+
+    if !stderr.is_empty() {
+        warn!("Command '{}' wrote to stderr: {}", command, stderr);
+    }
+
+    trace!("Command '{}' executed: {}", command, stdout);
+
+    if shell_config.parse_stderr && stdout.is_empty() {
+        Ok(stderr)
+    } else {
+        Ok(stdout)
+    }
 }
 
 #[cfg(test)]
@@ -1137,6 +1163,43 @@ text_sensor:
         assert!(
             text_sensor.update_interval.is_none(),
             "Minimal text_sensor should have no update_interval"
+        );
+    }
+
+    #[test]
+    fn test_shell_parse_stderr_defaults_to_false() {
+        let config = r#"
+ubihome:
+  name: "Test Shell Config"
+
+shell:
+  type: bash
+"#;
+
+        let module = UbiHomePlatform::new(config, "config.yml")
+            .expect("minimal shell config should be valid");
+        assert!(
+            !module.config.parse_stderr,
+            "parse_stderr should default to false"
+        );
+    }
+
+    #[test]
+    fn test_shell_parse_stderr_can_be_enabled() {
+        let config = r#"
+ubihome:
+  name: "Test Shell Config"
+
+shell:
+  type: bash
+  parse_stderr: true
+"#;
+
+        let module = UbiHomePlatform::new(config, "config.yml")
+            .expect("shell config with parse_stderr should be valid");
+        assert!(
+            module.config.parse_stderr,
+            "parse_stderr should be true when configured"
         );
     }
 

--- a/documentation/src/content/docs/features/platforms/shell.md
+++ b/documentation/src/content/docs/features/platforms/shell.md
@@ -21,8 +21,11 @@ shell:
 | Property        | Description                                   |
 | --------------- | --------------------------------------------- |
 | update_interval | How often to run the command. Default is 60s. |
+| parse_stderr    | If a command's stdout is empty, fall back to parsing its stderr instead. Default is `false`. |
 
 > In the future an update interval of `0` will allow you to stream the output of long running commands (e.g. a json log line by line).
+
+When a command exits with a non-zero status, both its stdout and stderr are included in the logged error, regardless of `parse_stderr`.
 
 ### Sensors
 

--- a/tests/platforms/shell/shell_stderr_test.py
+++ b/tests/platforms/shell/shell_stderr_test.py
@@ -1,0 +1,171 @@
+import asyncio
+
+import pytest
+
+from mock_file import IOMockFactory
+from utils import UbiHome
+
+
+async def test_parse_stderr_disabled_ignores_stderr_only_output(io_mock_factory: IOMockFactory):
+    """
+    A command that only writes to stderr must not be picked up unless
+    `shell.parse_stderr` is enabled.
+    """
+
+    switch_mock = io_mock_factory.create_mock()
+    sensor_mock = io_mock_factory.create_mock()
+
+    DEVICE_INFO_CONFIG = f"""
+ubihome:
+  name: test_device
+
+shell:
+
+switch:
+  - platform: shell
+    name: "Test Switch"
+    id: test_switch
+    command_on: "echo true > {switch_mock}"
+    command_off: "echo false > {switch_mock}"
+    command_state: "cat {switch_mock} || echo false"
+
+binary_sensor:
+  - platform: shell
+    name: "Test Binary Sensor"
+    update_interval: 1s
+    command: |-
+      cat {sensor_mock} 1>&2
+    on_press:
+      then:
+        - switch.turn_on: "test_switch"
+"""
+    sensor_mock.set_value("false")
+
+    async with UbiHome("run", config=DEVICE_INFO_CONFIG):
+        sensor_mock.set_value("true")
+
+        # If the stderr-only value had been picked up, the switch would have
+        # turned on; it must not, since parse_stderr is disabled.
+        with pytest.raises(TimeoutError):
+            await switch_mock.wait_for_mock_state("true", timeout=3)
+
+
+async def test_parse_stderr_enabled_falls_back_to_stderr_when_stdout_empty(io_mock_factory: IOMockFactory):
+    """
+    With `shell.parse_stderr` enabled, a command that only writes to stderr is
+    parsed the same way stdout-only output already is.
+    """
+
+    switch_mock = io_mock_factory.create_mock()
+    sensor_mock = io_mock_factory.create_mock()
+
+    DEVICE_INFO_CONFIG = f"""
+ubihome:
+  name: test_device
+
+shell:
+  parse_stderr: true
+
+switch:
+  - platform: shell
+    name: "Test Switch"
+    id: test_switch
+    command_on: "echo true > {switch_mock}"
+    command_off: "echo false > {switch_mock}"
+    command_state: "cat {switch_mock} || echo false"
+
+binary_sensor:
+  - platform: shell
+    name: "Test Binary Sensor"
+    update_interval: 1s
+    command: |-
+      cat {sensor_mock} 1>&2
+    on_press:
+      then:
+        - switch.turn_on: "test_switch"
+    on_release:
+      then:
+        - switch.turn_off: "test_switch"
+"""
+    sensor_mock.set_value("false")
+
+    async with UbiHome("run", config=DEVICE_INFO_CONFIG):
+        sensor_mock.set_value("true")
+        await switch_mock.wait_for_mock_state("true")
+        switch_mock.remove()
+
+        sensor_mock.set_value("false")
+        await switch_mock.wait_for_mock_state("false")
+
+
+async def test_stdout_preferred_over_stderr_even_when_parse_stderr_enabled(io_mock_factory: IOMockFactory):
+    """
+    `parse_stderr` is only a fallback for when stdout is empty: it must never
+    override real stdout output with stderr content.
+    """
+
+    switch_mock = io_mock_factory.create_mock()
+
+    DEVICE_INFO_CONFIG = f"""
+ubihome:
+  name: test_device
+
+shell:
+  parse_stderr: true
+
+switch:
+  - platform: shell
+    name: "Test Switch"
+    id: test_switch
+    command_on: "echo true > {switch_mock}"
+    command_off: "echo false > {switch_mock}"
+    command_state: "cat {switch_mock} || echo false"
+
+binary_sensor:
+  - platform: shell
+    name: "Test Binary Sensor"
+    update_interval: 1s
+    command: |-
+      echo false
+      echo true 1>&2
+    on_press:
+      then:
+        - switch.turn_on: "test_switch"
+"""
+
+    async with UbiHome("run", config=DEVICE_INFO_CONFIG):
+        # Stdout ("false") and stderr ("true") disagree; the switch must never
+        # turn on, proving stderr never wins while stdout has content.
+        with pytest.raises(TimeoutError):
+            await switch_mock.wait_for_mock_state("true", timeout=3)
+
+
+async def test_failure_logs_include_both_stdout_and_stderr():
+    """
+    When a command fails, the logged error must include both its stdout and
+    stderr, not just stderr.
+    """
+
+    DEVICE_INFO_CONFIG = """
+ubihome:
+  name: test_device
+
+shell:
+
+text_sensor:
+  - platform: shell
+    name: "Failing Command"
+    update_interval: 1s
+    command: |-
+      echo out message
+      echo err message 1>&2
+      exit 1
+"""
+
+    async with UbiHome("run", config=DEVICE_INFO_CONFIG) as ubihome:
+
+        async def wait_for_log():
+            while "out message" not in (ubihome.stdout or "") or "err message" not in (ubihome.stdout or ""):
+                await asyncio.sleep(0.1)
+
+        await asyncio.wait_for(wait_for_log(), timeout=5)


### PR DESCRIPTION
## Summary
- Command failures previously only surfaced stderr in logs (via `shell_exec`'s `ShellError::Failure(stderr)`), silently dropping stdout. Failure logs now include both streams.
- Successful commands that still wrote to stderr were silently ignored; these now log a warning.
- New `shell.parse_stderr` config option: when a command's stdout is empty, its stderr is fed through the same parsing path stdout already uses (numeric for sensors/numbers, true/false for binary sensors/switches, raw text for text sensors). Stdout always wins when non-empty, even with `parse_stderr` on.
- Depends on a fork of `shell_exec` (github.com/DanielHabenicht/fork.shell_exec, branch `stream-stdout-stderr`) that adds `execute_full`/`spawn`, returning both `stdout` and `stderr` regardless of exit status — upstream's `execute()` only ever returns one or the other depending on exit code. Tracked upstream at caido/shell_exec#2 and caido/shell_exec#3.

## Test plan
- [x] `cargo build` / `cargo fmt --all -- --check` / `cargo clippy --all-targets --all-features -- -D warnings` clean across the workspace
- [x] New e2e tests in `tests/platforms/shell/shell_stderr_test.py`, using only internal triggers (`on_press`/`switch.turn_on` + mock files, no `api` platform needed):
  - `parse_stderr` disabled ignores stderr-only output
  - `parse_stderr` enabled falls back to stderr when stdout is empty
  - stdout is still preferred over stderr when both have content, even with `parse_stderr` enabled
  - a failing command's log includes both stdout and stderr
- [x] Full Python test suite run locally; no regressions (one pre-existing flaky `number_test.py` timing test and Docker/Playwright-unavailable errors unrelated to this change)

Note: `Cargo.lock` pins `shell_exec` to a commit on the fork's branch, not a published crates.io release — will need updating if that branch changes before the fork is upstreamed/published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)